### PR TITLE
Release/0.0.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.pyc
+*.pyo
+.git/
+.gitignore
+Dockerfile
+docker-compose.yml
+.dockerignore
+README.md
+test_*.py
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+env/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - master 
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .env
 .omo/
 .pytest_cache/
+site/
+metrics_history.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .env
+.omo/
+.pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim-bookworm
+
+# Prevent Python from writing .pyc files and buffering stdout
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install dependencies first (cache layer)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app.py config.py utils.py service.py service_registry.py ./
+
+# Expose Flask port
+EXPOSE 5000
+
+# Use gunicorn for production-grade 24/7 operation
+# --bind 0.0.0.0:5000   → listen on all interfaces inside container
+# --workers 4             → 4 worker processes (adjust based on CPU cores)
+# --timeout 120           → 2 min timeout for long health checks
+# --access-logfile -      → log to stdout
+# --error-logfile -       → log errors to stdout
+# --capture-output        → capture stdout/stderr from workers
+# --enable-stdio-inheritance → forward worker logs
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "--access-logfile", "-", "--error-logfile", "-", "--capture-output", "--enable-stdio-inheritance", "app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
-COPY app.py config.py utils.py service.py service_registry.py ./
+COPY app.py config.py utils.py services.py service_registry.py ./
 
 # Expose Flask port
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM python:3.12-slim-bookworm
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# Install system runtime libraries (libsqlite3-0 for Python's built-in sqlite3 module)
+RUN apt-get update && apt-get install -y --no-install-recommends libsqlite3-0 curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Install dependencies first (cache layer)
@@ -12,17 +16,17 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
-COPY app.py config.py utils.py services.py service_registry.py ./
+COPY app.py config.py metrics.py utils.py services.py service_registry.py ./
 
 # Expose Flask port
 EXPOSE 5000
 
 # Use gunicorn for production-grade 24/7 operation
-# --bind 0.0.0.0:5000   → listen on all interfaces inside container
-# --workers 4             → 4 worker processes (adjust based on CPU cores)
-# --timeout 120           → 2 min timeout for long health checks
-# --access-logfile -      → log to stdout
-# --error-logfile -       → log errors to stdout
-# --capture-output        → capture stdout/stderr from workers
-# --enable-stdio-inheritance → forward worker logs
+# --bind 0.0.0.0:5000     -> listen on all interfaces inside container
+# --workers 4             -> 4 worker processes (adjust based on CPU cores)
+# --timeout 120           -> 2 min timeout for long health checks
+# --access-logfile        -> log to stdout
+# --error-logfile         -> log errors to stdout
+# --capture-output        -> capture stdout/stderr from workers
+# --enable-stdio-inheritance -> forward worker logs
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "--access-logfile", "-", "--error-logfile", "-", "--capture-output", "--enable-stdio-inheritance", "app:app"]

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,9 @@ stop:
 
 logs:
 	sudo docker compose logs -f
+
+docs-build:
+	mkdocs build
+
+docs-serve:
+	mkdocs serve

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build run stop logs
+
+build:
+	sudo docker compose build
+
+run:
+	sudo docker compose up -d
+
+stop:
+	sudo docker compose down
+
+logs:
+	sudo docker compose logs -f

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ curl -X POST http://localhost:5000/api/services/GetAllPosts/fail
 curl http://localhost:5000/api/metrics
 ```
 
+> [!TIP]
+> If you want to see the detailed information about the design, architecture, complete API reference alongside deployment instructions, you can check the [Architecture Document](./docs/architecture.md) that has been written in a more comprehensive way
+
 ### Caveats
 
 - No async support. By all means, the service assignment is synchronous and resolves to the first available index. If that service is also unhealthy, no fallback will be attempted automatically

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Given the context, we can implement several features that might help in the proc
 - Built-in logging mechanism
 - Gracefully shutdown a certain service
 - Thread-safe concurrent access with `threading.Lock` synchronization
+- Persistent event history — all service registrations, failures, assignments, health transitions, and request traces are recorded in a local SQLite database and queryable via API
 
 ### Usage
 
@@ -91,13 +92,37 @@ curl -X POST http://localhost:5000/api/services/GetAllPosts/fail
 curl http://localhost:5000/api/metrics
 ```
 
+**View event history**
+
+```sh
+curl http://localhost:5000/api/history
+```
+
+**Filter history by service name:**
+
+```sh
+curl "http://localhost:5000/api/history?service_name=GetAllPosts"
+```
+
+**Filter history by event type:**
+
+```sh
+curl "http://localhost:5000/api/history?event_type=service_failure"
+```
+
+**Limit results:**
+
+```sh
+curl "http://localhost:5000/api/history?limit=5"
+```
+
 > [!TIP]
 > If you want to see the detailed information about the design, architecture, complete API reference alongside deployment instructions, you can check the [Architecture Document](./docs/architecture.md) that has been written in a more comprehensive way
 
 ### Caveats
 
 - No async support. By all means, the service assignment is synchronous and resolves to the first available index. If that service is also unhealthy, no fallback will be attempted automatically
-- In-memory state. All registry data is held in memory and does not persist across restarts
+- In-memory state. The core registry state remains in memory (fast and ephemeral), but event history is now persisted to a local SQLite database so it survives restarts
 
 ### Acknowledgment
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Given the context, we can implement several features that might help in the proc
 - Distributed services tracing (trace all of the failure and success counts)
 - Built-in logging mechanism
 - Gracefully shutdown a certain service
+- Thread-safe concurrent access with `threading.Lock` synchronization
 
 ### Usage
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify
 from utils import check_downstream_health, DEFAULT_HEADERS
 from config import DOWNSTREAM_SERVICES
 from services import registry
+from metrics import get_events
 
 app = Flask(__name__)
 
@@ -131,6 +132,17 @@ def add_dependency():
 
     registry.register_dependency(service_name=service_name, depends_on=depends_on)
     return jsonify({"message": "Dependency registered successfully"}), 201
+
+
+# fetch all the metrics history based on the database table
+@app.route("/api/history", methods=["GET"])
+def get_history():
+    service_name = request.args.get("service_name")
+    event_type = request.args.get("event_type")
+    limit = request.args.get("limit", default=100, type=int)
+
+    events = get_events(service_name=service_name, event_type=event_type, limit=limit)
+    return jsonify(events), 200
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -1,16 +1,21 @@
 from flask import Flask, request, jsonify
-from service_registry import ServiceRegistryManagement
+from utils import check_downstream_health, DEFAULT_HEADERS
+from config import DOWNSTREAM_SERVICES
+from services import registry
 
 app = Flask(__name__)
-
-
-registry = ServiceRegistryManagement()
-registry.start_health_check()
 
 
 @app.route("/api/health", methods=["GET"])
 def health():
     return jsonify({"status": "OK"}), 200
+
+
+# this API will check the health of the downstream services
+@app.route("/api/external-health", methods=["GET"])
+def external_health():
+    result = check_downstream_health(DOWNSTREAM_SERVICES, DEFAULT_HEADERS)
+    return jsonify(result), 200
 
 
 # register the relevant/particular downstream services here so it can be exposed through Flask APIs
@@ -51,7 +56,7 @@ def get_service(service_name):
 
 
 # assigne particular service
-@app.route("/api/services/assign", methods=["GET"])
+@app.route("/api/services/assign", methods=["POST"])
 def assign_service():
     data = request.get_json()
 
@@ -62,7 +67,7 @@ def assign_service():
         return jsonify({"error": "missing parameter"}), 400
 
     registry.assign_service(
-        service_name=service_name, assigned_service_name=assign_service
+        service_name=service_name, assigned_service_name=assigned_service
     )
     return jsonify({"message": "Successfully assigned particular service"}), 200
 
@@ -129,4 +134,4 @@ def add_dependency():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000, host="0.0.0.0")
+    app.run(debug=False, port=5000, host="0.0.0.0", threaded=True)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,28 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# default headers for the health check request to downstream services, you can modify this as needed
+# this is used for bypassing the CloudFlare protection which gives you 403 forbidden if you don't have the correct headers
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Upgrade-Insecure-Requests": "1",
+}
+
+# downstream services that you want to monitor the health, you can register it here or through the API
+DOWNSTREAM_SERVICES = {
+    "Maukerja-Server": os.getenv("MAUKERJA_SERVER"),
+    "V3-API-BE": os.getenv("V3_API_BE"),
+    "BE-Chat-Health": os.getenv("BE_CHAT_HEALTH"),
+    "FE-Chat-Health-Node-Proxy": os.getenv("FE_CHAT_HEALTH_NODE_PROXY"),
+    "FE-Chat-Health-Apache-Proxy": os.getenv("FE_CHAT_HEALTH_APACHE_PROXY"),
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "5000:5000"
     environment:
       - PYTHONUNBUFFERED=1
+    env_file: .env
       # Optional: tweak gunicorn workers without rebuilding image
       # - GUNICORN_WORKERS=4
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  service-registry:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: service-registry
+    ports:
+      - "5000:5000"
+    environment:
+      - PYTHONUNBUFFERED=1
+      # Optional: tweak gunicorn workers without rebuilding image
+      # - GUNICORN_WORKERS=4
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    # Resource limits to prevent runaway growth
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,371 @@
+# API Reference
+
+The service registry exposes a REST API via Flask. All endpoints are prefixed with `/api`.
+
+## Endpoint Quick Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/health` | Registry self-health check |
+| `GET` | `/api/external-health` | Health of all downstream services |
+| `POST` | `/api/services` | Register a new service |
+| `GET` | `/api/services` | List all registered services |
+| `GET` | `/api/service/{name}` | Resolve a service URL (follows assignments) |
+| `POST` | `/api/services/assign` | Assign one service to another |
+| `POST` | `/api/services/{name}/fail` | Mark a service as unhealthy |
+| `POST` | `/api/services/{name}/call` | Simulate and trace a request |
+| `GET` | `/api/services/{name}/ready` | Check if a service is ready |
+| `POST` | `/api/dependencies` | Register a dependency between services |
+| `GET` | `/api/metrics` | Read request tracing counters |
+| `GET` | `/api/history` | Query event history from SQLite |
+| `DELETE` | `/api/services/{name}` | Deregister a service |
+
+---
+
+## Registry Health
+
+### `GET /api/health`
+
+Returns the registry's own health status. Used by Docker health checks.
+
+**Response `200 OK`:**
+
+```json
+{
+  "status": "OK"
+}
+```
+
+---
+
+## Downstream Health
+
+### `GET /api/external-health`
+
+Probes every registered downstream service URL with browser-grade headers and returns per-service status.
+
+**Response `200 OK`:**
+
+```json
+{
+  "status": "healthy",
+  "timestamp": 1718000000000,
+  "services": [
+    {
+      "name": "Maukerja-Server",
+      "url": "https://maukerja.example.com/health",
+      "status_code": 200,
+      "healthy": true,
+      "response": { ... }
+    }
+  ]
+}
+```
+
+The `status` field is one of:
+
+| Value | Meaning |
+|-------|---------|
+| `healthy` | All services returned 200 |
+| `degraded` | At least one service returned 200 |
+| `unhealthy` | No services returned 200 |
+
+---
+
+## Service Registration
+
+### `POST /api/services`
+
+Register a new downstream service.
+
+**Request body:**
+
+```json
+{
+  "service_name": "MyAPI",
+  "service_url": "https://api.example.com/health"
+}
+```
+
+**Response `201 Created`:**
+
+```json
+{
+  "message": "service registered"
+}
+```
+
+**Response `400 Bad Request`:**
+
+```json
+{
+  "error": "Service already registered, please use another service name"
+}
+```
+
+---
+
+### `GET /api/services`
+
+List all registered services with their current state.
+
+**Response `200 OK`:**
+
+```json
+{
+  "MyAPI": {
+    "url": "https://api.example.com/health",
+    "assigned": false,
+    "assigned_service": null,
+    "availability": "AVAILABLE"
+  }
+}
+```
+
+---
+
+### `GET /api/service/{name}`
+
+Resolve the URL for a given service. Follows assignment chains transparently — if `ServiceA` is assigned to `ServiceB`, this returns `ServiceB`'s URL.
+
+**Response `200 OK`:**
+
+```json
+{
+  "service_name": "MyAPI",
+  "url": "https://api.example.com/health"
+}
+```
+
+**Response `404 Not Found`:**
+
+```json
+{
+  "error": "There's no available service"
+}
+```
+
+---
+
+### `DELETE /api/services/{name}`
+
+Deregister a service and remove its circuit breaker state.
+
+**Response `200 OK`:**
+
+```json
+{
+  "message": "service deregistered"
+}
+```
+
+**Response `404 Not Found`:**
+
+```json
+{
+  "error": "Service name is not registered in the list of service register"
+}
+```
+
+---
+
+## Service Assignment
+
+### `POST /api/services/assign`
+
+Assign one service to another. When the source service is looked up, the registry returns the assigned service's URL instead.
+
+**Request body:**
+
+```json
+{
+  "service_name": "MyAPI",
+  "assigned_service": "V3-API-BE"
+}
+```
+
+**Response `200 OK`:**
+
+```json
+{
+  "message": "Successfully assigned particular service"
+}
+```
+
+---
+
+## Failure Simulation
+
+### `POST /api/services/{name}/fail`
+
+Force a service into the `DOWN` state. Useful for testing how upstream services react when a downstream dependency disappears.
+
+**Response `200 OK`:**
+
+```json
+{
+  "message": "marked this service is unhealthy"
+}
+```
+
+---
+
+## Request Tracing
+
+### `POST /api/services/{name}/call`
+
+Simulate a request to a service. Records the trace in in-memory counters and persists an event to SQLite.
+
+**Response `200 OK`:**
+
+```json
+{
+  "message": "Request traced successfully"
+}
+```
+
+---
+
+## Readiness Check
+
+### `GET /api/services/{name}/ready`
+
+Check if a service is ready based on its dependency graph. A service is ready only when all services it depends on are `AVAILABLE`.
+
+**Response `200 OK`:**
+
+```json
+{
+  "message": "Service is ready"
+}
+```
+
+**Response `503 Service Unavailable`:**
+
+```json
+{
+  "message": "Service is not ready"
+}
+```
+
+---
+
+## Dependencies
+
+### `POST /api/dependencies`
+
+Register a dependency between services. Once registered, the dependent service's readiness is gated on its dependencies being healthy.
+
+**Request body:**
+
+```json
+{
+  "service_name": "MyAPI",
+  "depends_on": "V3-API-BE"
+}
+```
+
+**Response `201 Created`:**
+
+```json
+{
+  "message": "Dependency registered successfully"
+}
+```
+
+---
+
+## Metrics
+
+### `GET /api/metrics`
+
+Read the in-memory request tracing counters aggregated across all services.
+
+**Response `200 OK`:**
+
+```json
+{
+  "total_requests": 42,
+  "successful_requests": 40,
+  "failure_requests": 2,
+  "duration": 21.5
+}
+```
+
+---
+
+## Event History
+
+### `GET /api/history`
+
+Query the SQLite-persisted event history. Supports optional filters.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `service_name` | string | — | Filter by service name |
+| `event_type` | string | — | Filter by event type |
+| `limit` | integer | 100 | Maximum number of events to return |
+
+**Example requests:**
+
+```bash
+# All events
+curl http://localhost:5000/api/history
+
+# Events for a specific service
+curl "http://localhost:5000/api/history?service_name=MyAPI"
+
+# Events of a specific type
+curl "http://localhost:5000/api/history?event_type=service_failure"
+
+# Last 5 events
+curl "http://localhost:5000/api/history?limit=5"
+```
+
+**Response `200 OK`:**
+
+```json
+[
+  {
+    "timestamp": 1718000000.123,
+    "service_name": "MyAPI",
+    "event_type": "service_registered",
+    "detail": "https://api.example.com/health"
+  },
+  {
+    "timestamp": 1718000010.456,
+    "service_name": "MyAPI",
+    "event_type": "health_check_healthy",
+    "detail": "state changed to AVAILABLE"
+  }
+]
+```
+
+### Event Types
+
+| Event Type | Trigger | Detail |
+|---|---|---|
+| `service_registered` | Service registration | URL of the registered service |
+| `service_deregistered` | Service deregistration | Name of the deregistered service |
+| `service_assigned` | Service assignment | `"ServiceA assigned to ServiceB"` |
+| `service_failure` | Simulated failure | `"simulated failure"` |
+| `request_traced` | Request simulation | Name of the traced service |
+| `dependency_registered` | Dependency registration | `"ServiceA depends on ServiceB"` |
+| `health_check_healthy` | Health check → AVAILABLE | `"state changed to AVAILABLE"` |
+| `health_check_unhealthy` | Health check → DOWN | `"state changed to DOWN"` |
+
+---
+
+## Error Responses
+
+All endpoints return standard HTTP status codes:
+
+| Code | Meaning |
+|------|---------|
+| `200` | Success |
+| `201` | Created |
+| `400` | Bad request (missing or invalid parameters) |
+| `404` | Service not found |
+| `503` | Service not ready (dependencies unhealthy) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,61 @@ flowchart LR
   B -->|200 OK| G[Metrics Updated]
 ```
 
-## 6. Simulating Failures
+## 6. Event History (SQLite Persistence)
+
+The registry keeps runtime state in memory for speed, but that state vanishes on restart. To preserve an audit trail of what happened, every meaningful operation now calls `record_event()` in `metrics.py`, which writes to a local SQLite database (`metrics_history.db`).
+
+### How It Works
+
+Each public operation that mutates or queries registry state triggers a single `INSERT` into the `service_events` table. The row stores a Unix epoch timestamp, the service name, an event type, and a free-text detail string. Because SQLite is embedded, there is no separate server process, thus the database file lives alongside the application
+
+### Transaction Safety
+
+SQLite itself is thread-safe for reads, but concurrent writes can deadlock or corrupt the journal if multiple threads commit at the exact same moment. To avoid this, all write paths acquire a dedicated `threading.Lock` before opening a connection. This serialises inserts so only one thread can commit at a single time
+
+The database is opened in **WAL (Write-Ahead Logging) mode**. WAL allows readers to proceed while a writer is appending to the log, so the `GET /api/history` endpoint never blocks on an active `record_event()` call.
+
+### Event Types
+
+| Event Type | Triggered By | Detail Example |
+|---|---|---|
+| `service_registered` | `register_services()` | URL of the registered service |
+| `service_deregistered` | `deregister_service()` | Name of the deregistered service |
+| `service_assigned` | `assign_service()` | `"ServiceA assigned to ServiceB"` |
+| `service_failure` | `simulate_service_is_unhealthy()` | `"simulated failure"` (only on state transition) |
+| `request_traced` | `trace_service_request()` | Name of the traced service |
+| `dependency_registered` | `register_dependency()` | `"ServiceA depends on ServiceB"` |
+| `health_check_healthy` | `_simulate_health_check()` | `"state changed to AVAILABLE"` (only on transition) |
+| `health_check_unhealthy` | `_simulate_health_check()` | `"state changed to DOWN"` (only on transition) |
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client as HTTP Client
+    participant Flask as Flask API
+    participant Registry as ServiceRegistry
+    participant Metrics as metrics.py (SQLite)
+    participant DB as metrics_history.db
+
+    Client->>Flask: POST /api/services (register)
+    Flask->>Registry: register_services()
+    Registry->>Metrics: record_event("service_registered")
+    Metrics->>DB: INSERT with WAL mode
+    DB-->>Metrics: OK
+    Metrics-->>Registry: done
+    Registry-->>Flask: return
+    Flask-->>Client: 201 Created
+
+    Client->>Flask: GET /api/history
+    Flask->>Metrics: get_events(service_name, event_type, limit)
+    Metrics->>DB: SELECT with filters
+    DB-->>Metrics: rows
+    Metrics-->>Flask: events list
+    Flask-->>Client: JSON array
+```
+
+## 7. Simulating Failures
 
 You can force a service into the `DOWN` state with `POST /api/services/<name>/fail`. This is quite straightforward and pretty useful for testing how upstream services react when a downstream dependency disappears. Since, the main sources of the Chat services were invoked through different party
 
@@ -166,7 +220,7 @@ sequenceDiagram
   Registry-->>Client: 503 Not Ready
 ```
 
-## 7. API Endpoints
+## 8. API Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -181,9 +235,10 @@ sequenceDiagram
 | `GET` | `/api/services/:name/ready` | Check if service is ready (deps healthy) |
 | `POST` | `/api/dependencies` | Register a dependency |
 | `GET` | `/api/metrics` | Read request tracing counters |
+| `GET` | `/api/history` | Query event history (params: `service_name`, `event_type`, `limit`) |
 | `DELETE` | `/api/services/:name` | Deregister a service |
 
-## 8. Data Flow Summary
+## 9. Data Flow Summary
 
 ```mermaid
 flowchart TB
@@ -191,6 +246,7 @@ flowchart TB
     A[Flask App]
     B[ServiceRegistryManagement]
     C[Health Check Thread]
+    E[Metrics (SQLite)]
   end
 
   subgraph "Downstream Services"
@@ -208,17 +264,19 @@ flowchart TB
   C -->|HTTP GET every 5s| D4
   C -->|HTTP GET every 5s| D5
   B -->|Metrics| A
+  B -->|Event History| E
+  A -->|Query| E
 ```
 
-## 9. Caveats
+## 10. Caveats
 
 At the moment, there were a few items that needed to be addressed before they were going to be adopted or at least made as production-grade ready. Those are:
 
 - **No async support**. By all means, the service assignment is synchronous and resolves to the first available index. If that service is also unhealthy, no fallback will be attempted automatically
-- **In-memory state**. All registry data is held in memory and does not persist across restarts. There is no database or external storage which holds logs or particular events
+- **Hybrid state model**. The core registry (service registrations, assignments, health status) remains in-memory for performance and it's ephemeral. However, event history is persisted to a local SQLite database that survives restarts. The two layers are intentionally separated: fast in-memory state for runtime operations, durable SQLite storage for audit and observability
 - **Single instance**. No clustering or leader election is implemented
 
-## 10. Getting Started
+## 11. Getting Started
 
 ```bash
 # Start the server
@@ -241,7 +299,7 @@ curl -X POST http://localhost:5000/api/services/MyAPI/call
 curl http://localhost:5000/api/metrics
 ```
 
-## 11. History & Origin
+## 12. History & Origin
 
 This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 by myself as an internal exploration into service mesh patterns and self-healing architectures.
 
@@ -249,20 +307,20 @@ Initially, the team did not adopt Jaeger or OpenTelemetry back in 2021. However,
 
 Fast forward to 2026: the chat services needed to become fully independent and required their own lightweight monitoring system. In June 2026, this library resurfaced. The Backend and Frontend teams decided to run live experiments with it as a dedicated health-check and service-assignment layer for the chat infrastructure, reviving the original codebase and extending it with real downstream services
 
-## 12. Production Deployment (24/7)
+## 13. Production Deployment (24/7)
 
 The repository includes a Docker Compose setup designed for continuous operation.
 
-### 12.1 Docker Compose Stack
+### 13.1 Docker Compose Stack
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Python 3.12 slim image with Gunicorn as the WSGI server |
+| `Dockerfile` | Python 3.12 slim image with Gunicorn as the WSGI server. Copies `app.py`, `config.py`, `metrics.py`, `utils.py`, `services.py`, and `service_registry.py`. Installs `libsqlite3-0` as a system dependency for SQLite support |
 | `docker-compose.yml` | Orchestrates the container with restart policy and health checks |
 | `requirements.txt` | Pins Flask, Requests, and Gunicorn versions |
 | `.dockerignore` | Keeps the image lean |
 
-### 12.2 Key Production Settings
+### 13.2 Key Production Settings
 
 - **Gunicorn** runs with 4 workers and a 120-second timeout to handle slow downstream responses.
 - **Restart policy** is set to `always` so the container recovers automatically after a host reboot or crash.
@@ -270,7 +328,7 @@ The repository includes a Docker Compose setup designed for continuous operation
 - **Resource limits** are capped at 1 CPU and 512 MB RAM to prevent a runaway process from starving the host.
 - **Flask** runs with `debug=False` and `threaded=True` for safe concurrent request handling.
 
-### 12.3 Deploy
+### 13.3 Deploy
 
 ```bash
 # Build and start
@@ -283,7 +341,7 @@ docker compose logs -f
 docker compose down && docker compose up --build -d
 ```
 
-### 12.4 Monitoring
+### 13.4 Monitoring
 
 Because the library is in-memory, you should monitor the host itself:
 
@@ -292,13 +350,13 @@ Because the library is in-memory, you should monitor the host itself:
 - **Downstream health** via the `/api/external-health` endpoint (poll every 60s)
 - **Request metrics** via `/api/metrics` (total, success, failure counts)
 
-## 13. Future Considerations
+## 14. Future Considerations
 
 This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh. Especially, the targeted environment possibly grows larger since we also need to opt-in the Chat services for other platforms
 
 | Improvement | Rationale |
 |-------------|-----------|
-| **Persistent state** | SQLite or Redis so registrations and assignments survive restarts |
+| **Persistent state (partially addressed)** | Event history is now persisted via SQLite. Future work could extend persistence to service registrations and assignments using SQLite, Redis, or an external database |
 | **Async health checks** | `asyncio` or `aiohttp` to avoid blocking the GIL during slow probes |
 | **Clustering** | Multiple instances with a shared backend (for example, Consul or etcd) for high availability |
 | **Authentication** | API key or mTLS on the registry endpoints to prevent unauthorized deregistration |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Service Registry Architecture
 
-This document explains the internals of the service registry library and the topology mesh that has been wired up.
+This document explains the internals of the service registry management library and the topology mesh that has been wired up within MauKerja chat services on the production environment. It covers the design decisions, data flow, and how the library simulates a service registry pattern with circuit breaker and health checking features. The document also includes API endpoints, usage examples, and future considerations for production deployment
 
 ## 1. Overview
 
@@ -8,15 +8,15 @@ The library implements a lightweight service registry pattern inspired by Netfli
 
 | Feature | Purpose |
 |---------|---------|
-| **Service Registration** | Register a service name → URL mapping and hold it in memory. |
-| **Service Assignment** | Route a service to another one so the caller always hits an available instance. |
-| **Health Checking** | Periodically probe each registered URL and mark it `AVAILABLE`, `STARTING`, or `DOWN`. |
-| **Circuit Breaker** | After 3 consecutive failures, open the circuit and stop hammering the unhealthy service for 5 seconds. |
-| **Request Tracing** | Count total, successful, and failed requests, and measure cumulative duration. |
+| **Service Registration** | Register a service name, URL mapping and hold it in memory |
+| **Service Assignment** | Route a service to another one so the caller always hits an available instance |
+| **Health Checking** | Periodically probe each registered URL and mark it `AVAILABLE`, `STARTING`, or `DOWN` |
+| **Circuit Breaker** | After 3 consecutive failures, open the circuit and stop hammering the unhealthy service for 5 seconds |
+| **Request Tracing** | Count total, successful, and failed requests, and measure cumulative duration |
 
 ## 2. Topology Mesh
 
-The system is pre-registered with five downstream services. Two of them are chained together via assignments, while three others are independent. Dependencies define readiness constraints.
+The current implementation as per the first week of June 2026, the system is pre-registered with five downstream services which are related to the Chat services that are widely used on the MauKerja platform. Two of them are chained together via assignments, while three others are independent. Dependencies define readiness constraints:
 
 ```mermaid
 graph LR
@@ -65,7 +65,7 @@ sequenceDiagram
 
 ### 2.2 Dependencies
 
-A dependency means a service will only be considered *ready* when all the services it depends on are healthy.
+A background daemon thread wakes up every 5 seconds and probes each registered service URL. The request includes real browser headers to bypass CloudFlare bot detection such as with user-agent or upgrade-insecure-requests.
 
 | Service | Readiness Gate |
 |---------|-------------|
@@ -77,7 +77,7 @@ A dependency means a service will only be considered *ready* when all the servic
 
 ## 3. Health Checking
 
-A background daemon thread wakes up every 5 seconds and probes each registered service URL.
+A background daemon thread wakes up every 5 seconds and probes each registered service URL. The request includes real browser headers to bypass CloudFlare bot detection such as with `user-agent` or `upgrade-insecure-requests`.
 
 ```mermaid
 flowchart TD
@@ -96,14 +96,12 @@ flowchart TD
   B -->|No| K[Wait...]
 ```
 
-The request includes real browser headers to bypass CloudFlare bot detection (User-Agent, Accept, Sec-Fetch-*, etc.).
-
 ## 4. Circuit Breaker
 
 Every health check call is wrapped in a circuit breaker with:
 
 - **Threshold:** 3 consecutive failures before opening the circuit
-- **Timeout:** 5 seconds in OPEN state before trying again (HALF_OPEN)
+- **Timeout:** 5 seconds in OPEN state before trying again (`HALF_OPEN`)
 
 ```mermaid
 stateDiagram-v2
@@ -138,7 +136,7 @@ flowchart LR
 
 ## 6. Simulating Failures
 
-You can force a service into the `DOWN` state with `POST /api/services/<name>/fail`.
+You can force a service into the `DOWN` state with `POST /api/services/<name>/fail`. This is quite straightforward and pretty useful for testing how upstream services react when a downstream dependency disappears. Since, the main sources of the Chat services were invoked through different party
 
 ```mermaid
 sequenceDiagram
@@ -153,8 +151,6 @@ sequenceDiagram
   Registry->>Registry: Check dependencies
   Registry-->>Client: 503 Not Ready
 ```
-
-This is useful for testing how upstream services react when a downstream dependency disappears.
 
 ## 7. API Endpoints
 
@@ -202,10 +198,11 @@ flowchart TB
 
 ## 9. Caveats
 
-- **In-memory only.** All state is lost when the process restarts.
-- **Synchronous.** Service resolution and health checks are single-threaded per service.
-- **No persistence.** There is no database or external storage.
-- **Single instance.** No clustering or leader election is implemented.
+At the moment, there were a few items that needed to be addressed before they were going to be adopted or at least made as production-grade ready. Those are:
+
+- **No async support**. By all means, the service assignment is synchronous and resolves to the first available index. If that service is also unhealthy, no fallback will be attempted automatically
+- **In-memory state**. All registry data is held in memory and does not persist across restarts. There is no database or external storage which holds logs or particular events
+- **Single instance**. No clustering or leader election is implemented
 
 ## 10. Getting Started
 
@@ -232,11 +229,11 @@ curl http://localhost:5000/api/metrics
 
 ## 11. History & Origin
 
-This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 by the original author as an internal exploration into service mesh patterns and self-healing architectures.
+This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 by myself as an internal exploration into service mesh patterns and self-healing architectures.
 
-Initially, the team did not adopt Jaeger or OpenTelemetry back in 2021. However, by the end of 2023, both tracing systems were eventually adopted across the broader platform, and this experimental library was gradually shelved and postponed.
+Initially, the team did not adopt Jaeger or OpenTelemetry back in 2021. However, by the end of 2023, both tracing systems were eventually adopted across the broader platform, and this experimental library was gradually shelved and postponed
 
-Fast forward to 2026: the chat services needed to become fully independent and required their own lightweight monitoring system. In June 2026, this library resurfaced. The Backend and Frontend teams decided to run live experiments with it as a dedicated health-check and service-assignment layer for the chat infrastructure, reviving the original codebase and extending it with real downstream services.
+Fast forward to 2026: the chat services needed to become fully independent and required their own lightweight monitoring system. In June 2026, this library resurfaced. The Backend and Frontend teams decided to run live experiments with it as a dedicated health-check and service-assignment layer for the chat infrastructure, reviving the original codebase and extending it with real downstream services
 
 ## 12. Production Deployment (24/7)
 
@@ -283,17 +280,16 @@ Because the library is in-memory, you should monitor the host itself:
 
 ## 13. Future Considerations
 
-This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh:
+This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh. Especially, the targeted environment possibly grows larger since we also need to opt-in the Chat services for other platforms
 
 | Improvement | Rationale |
 |-------------|-----------|
 | **Persistent state** | SQLite or Redis so registrations and assignments survive restarts |
 | **Async health checks** | `asyncio` or `aiohttp` to avoid blocking the GIL during slow probes |
-| **Clustering** | Multiple instances with a shared backend (e.g., Consul, etcd) for high availability |
+| **Clustering** | Multiple instances with a shared backend (for example, Consul or etcd) for high availability |
 | **Authentication** | API key or mTLS on the registry endpoints to prevent unauthorized deregistration |
 | **Prometheus metrics** | Export counters and histograms in `/metrics` format for scraping |
 | **Load balancing strategies** | Round-robin or least-latency instead of first-available assignment |
 | **Custom health thresholds** | Per-service timeout and failure-threshold configuration |
-| **Webhook notifications** | Alert Slack / PagerDuty when a downstream service goes DOWN |
 | **Graceful shutdown** | Drain in-flight requests before stopping the health check thread |
 | **TLS termination** | Run Gunicorn with certificates instead of handling TLS inside Flask |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,13 @@
-# Service Registry Architecture
+# Production Topology: MauKerja Chat Infrastructure
 
-This document explains the internals of the service registry management library and the topology mesh that has been wired up within MauKerja chat services on the production environment. It covers the design decisions, data flow, and how the library simulates a service registry pattern with circuit breaker and health checking features. The document also includes API endpoints, usage examples, and future considerations for production deployment
+This document describes how the service registry is used in a real production environment: the MauKerja chat infrastructure as of June 2026.
 
-## 1. Overview
+The system is pre-registered with five downstream services. Two are chained together via assignments, while three are independent. Dependencies define readiness constraints across the mesh.
 
-The library implements a lightweight service registry pattern inspired by Netflix Hystrix. It provides four main building blocks:
+!!! note
+    This is a **real-world example**. Your own topology will differ. You may edit [`services.py`](https://github.com/sodrooome/service-registry/blob/main/services.py) to match your services, assignments, and dependencies.
 
-| Feature | Purpose |
-|---------|---------|
-| **Service Registration** | Register a service name, URL mapping and hold it in memory |
-| **Service Assignment** | Route a service to another one so the caller always hits an available instance |
-| **Health Checking** | Periodically probe each registered URL and mark it `AVAILABLE`, `STARTING`, or `DOWN` |
-| **Circuit Breaker** | After 3 consecutive failures, open the circuit and stop hammering the unhealthy service for 5 seconds |
-| **Request Tracing** | Count total, successful, and failed requests, and measure cumulative duration |
-
-## 2. Topology Mesh
-
-The current implementation as per the first week of June 2026, the system is pre-registered with five downstream services which are related to the Chat services that are widely used on the MauKerja platform. Two of them are chained together via assignments, while three others are independent. Dependencies define readiness constraints:
+## Topology Mesh
 
 ```mermaid
 graph LR
@@ -41,9 +32,9 @@ graph LR
   end
 ```
 
-### 2.1 Assignments
+### Assignments
 
-Assignments create a routing chain. When you ask the registry for `FE-Chat-Health-Apache-Proxy`, it transparently returns the URL of `FE-Chat-Health-Node-Proxy`. Ask for the Node proxy and you get `BE-Chat-Health`.
+Assignments create a routing chain. When you resolve `FE-Chat-Health-Apache-Proxy`, the registry transparently returns the URL of `FE-Chat-Health-Node-Proxy`. Resolving that returns `BE-Chat-Health`:
 
 ```mermaid
 sequenceDiagram
@@ -63,148 +54,61 @@ sequenceDiagram
   Registry-->>Client: Chat Service URL
 ```
 
-### 2.2 Dependencies
+This is how the Apache proxy routes through Node.js to the backend chat service — a chain of three hops collapsed into a single lookup.
 
-A dependency means a service will only be considered ready when all the services it depends on are healthy.
+### Dependencies
+
+A dependency means a service is only considered **ready** when all services it depends on are `AVAILABLE`:
 
 | Service | Readiness Gate |
-|---------|-------------|
-| `Maukerja-Server` | `V3-API-BE` AND `BE-Chat-Health` must be AVAILABLE |
+|---------|----------------|
+| `Maukerja-Server` | `V3-API-BE` **AND** `BE-Chat-Health` must be AVAILABLE |
 | `FE-Chat-Health-Node-Proxy` | `BE-Chat-Health` must be AVAILABLE |
 | `FE-Chat-Health-Apache-Proxy` | `FE-Chat-Health-Node-Proxy` must be AVAILABLE |
 | `BE-Chat-Health` | No dependencies (always ready if AVAILABLE) |
 | `V3-API-BE` | No dependencies (always ready if AVAILABLE) |
 
-## 3. Health Checking
+## Wiring It Up
 
-A background daemon thread wakes up every 5 seconds and probes each registered service URL. The request includes real browser headers to bypass CloudFlare bot detection such as with `user-agent` or `upgrade-insecure-requests`.
+This topology is defined in [`services.py`](https://github.com/sodrooome/service-registry/blob/main/services.py):
 
-```mermaid
-flowchart TD
-  A[Start Health Check Thread] --> B{Is there a registered service?}
-  B -->|Yes| C[Pick next service]
-  C --> D[HTTP GET /health with browser headers]
-  D --> E{Status Code 200?}
-  E -->|Yes| F[Mark AVAILABLE + healthy=True]
-  E -->|No| G[Mark DOWN + healthy=False]
-  G --> H[Increment failure_requests]
-  F --> I{More services?}
-  G --> I
-  I -->|Yes| C
-  I -->|No| J[Sleep 5 seconds]
-  J --> B
-  B -->|No| K[Wait...]
+```python
+# Register all downstream services from config
+for name, url in DOWNSTREAM_SERVICES.items():
+    registry.register_services(service_name=name, service_url=url)
+
+# Chain the proxies
+registry.assign_service(
+    service_name="FE-Chat-Health-Apache-Proxy",
+    assigned_service_name="FE-Chat-Health-Node-Proxy",
+)
+registry.assign_service(
+    service_name="FE-Chat-Health-Node-Proxy",
+    assigned_service_name="BE-Chat-Health",
+)
+
+# Define dependency readiness gates
+registry.register_dependency(
+    service_name="FE-Chat-Health-Node-Proxy",
+    depends_on="BE-Chat-Health",
+)
+registry.register_dependency(
+    service_name="FE-Chat-Health-Apache-Proxy",
+    depends_on="FE-Chat-Health-Node-Proxy",
+)
+registry.register_dependency(
+    service_name="Maukerja-Server",
+    depends_on="V3-API-BE",
+)
+registry.register_dependency(
+    service_name="Maukerja-Server",
+    depends_on="BE-Chat-Health",
+)
 ```
 
-## 3.1 Thread Safety
+## Simulating a Failure in This Topology
 
-Because the health check runs on a background daemon thread while API handlers run on Flask's request threads, shared mutable state needs protection from concurrent access. Every `ServiceRegistry` instance holds a single `threading.Lock` from context manager that guards:
-
-- `registered_services`: all reads, writes, and existence checks acquire the lock
-- `service_tracing`: counter updates for total, success, and failure requests
-
-The lock is acquired via the `with self._lock` context manager so it's always released, even when an exception propagates. Every public method that reads or mutates registry state follows this pattern. Apart from that, there are critical sections that required recent fixes, those are:
-
-- Look up, health check, and return now all happen inside a single critical section. Previously the return sat outside the lock, creating a race where a concurrent `deregister_service` could delete the key between the check and the access
-- The existence guard and the state mutation (`availability`, `healthy`, `failure_requests`) are now covered by the same lock. Previously only the guard was locked, leaving a race window for the mutation
-
-The `CircuitBreaker` class uses a separate dedicated lock to guard the circuit state transitions of circuit breaker alongside `failure_counts`. This is intentionally split from the registry lock to avoid unnecessary contention such as when circuit state and registry state are independent concerns
-
-## 4. Circuit Breaker
-
-Every health check call is wrapped in a circuit breaker with:
-
-- **Threshold:** 3 consecutive failures before opening the circuit
-- **Timeout:** 5 seconds in OPEN state before trying again (`HALF_OPEN`)
-
-```mermaid
-stateDiagram-v2
-  [*] --> CLOSED
-  CLOSED --> OPEN : 3 failures
-  OPEN --> HALF_OPEN : after 5s timeout
-  HALF_OPEN --> CLOSED : 1 success
-  HALF_OPEN --> OPEN : failure
-  CLOSED --> CLOSED : success
-```
-
-When the circuit is **OPEN**, any further request returns `None` immediately without touching the network. This prevents cascading overload on an already failing downstream.
-
-## 5. Request Tracing
-
-When you simulate a call with `POST /api/services/<name>/call`, the registry increments global counters:
-
-- `total_requests`
-- `successful_requests` (always true for simulation)
-- `failure_requests`
-- `duration` (cumulative)
-
-```mermaid
-flowchart LR
-  A[Client] -->|POST /call| B[Service Registry]
-  B --> C[Trace Service Request]
-  C --> D[total_requests += 1]
-  C --> E[successful_requests += 1]
-  C --> F[duration += 0.5s]
-  B -->|200 OK| G[Metrics Updated]
-```
-
-## 6. Event History (SQLite Persistence)
-
-The registry keeps runtime state in memory for speed, but that state vanishes on restart. To preserve an audit trail of what happened, every meaningful operation now calls `record_event()` in `metrics.py`, which writes to a local SQLite database (`metrics_history.db`).
-
-### How It Works
-
-Each public operation that mutates or queries registry state triggers a single `INSERT` into the `service_events` table. The row stores a Unix epoch timestamp, the service name, an event type, and a free-text detail string. Because SQLite is embedded, there is no separate server process, thus the database file lives alongside the application
-
-### Transaction Safety
-
-SQLite itself is thread-safe for reads, but concurrent writes can deadlock or corrupt the journal if multiple threads commit at the exact same moment. To avoid this, all write paths acquire a dedicated `threading.Lock` before opening a connection. This serialises inserts so only one thread can commit at a single time
-
-The database is opened in **WAL (Write-Ahead Logging) mode**. WAL allows readers to proceed while a writer is appending to the log, so the `GET /api/history` endpoint never blocks on an active `record_event()` call.
-
-### Event Types
-
-| Event Type | Triggered By | Detail Example |
-|---|---|---|
-| `service_registered` | `register_services()` | URL of the registered service |
-| `service_deregistered` | `deregister_service()` | Name of the deregistered service |
-| `service_assigned` | `assign_service()` | `"ServiceA assigned to ServiceB"` |
-| `service_failure` | `simulate_service_is_unhealthy()` | `"simulated failure"` (only on state transition) |
-| `request_traced` | `trace_service_request()` | Name of the traced service |
-| `dependency_registered` | `register_dependency()` | `"ServiceA depends on ServiceB"` |
-| `health_check_healthy` | `_simulate_health_check()` | `"state changed to AVAILABLE"` (only on transition) |
-| `health_check_unhealthy` | `_simulate_health_check()` | `"state changed to DOWN"` (only on transition) |
-
-### Sequence Diagram
-
-```mermaid
-sequenceDiagram
-    participant Client as HTTP Client
-    participant Flask as Flask API
-    participant Registry as ServiceRegistry
-    participant Metrics as metrics.py (SQLite)
-    participant DB as metrics_history.db
-
-    Client->>Flask: POST /api/services (register)
-    Flask->>Registry: register_services()
-    Registry->>Metrics: record_event("service_registered")
-    Metrics->>DB: INSERT with WAL mode
-    DB-->>Metrics: OK
-    Metrics-->>Registry: done
-    Registry-->>Flask: return
-    Flask-->>Client: 201 Created
-
-    Client->>Flask: GET /api/history
-    Flask->>Metrics: get_events(service_name, event_type, limit)
-    Metrics->>DB: SELECT with filters
-    DB-->>Metrics: rows
-    Metrics-->>Flask: events list
-    Flask-->>Client: JSON array
-```
-
-## 7. Simulating Failures
-
-You can force a service into the `DOWN` state with `POST /api/services/<name>/fail`. This is quite straightforward and pretty useful for testing how upstream services react when a downstream dependency disappears. Since, the main sources of the Chat services were invoked through different party
+You can force a service into the `DOWN` state to observe how the readiness chain reacts:
 
 ```mermaid
 sequenceDiagram
@@ -220,25 +124,7 @@ sequenceDiagram
   Registry-->>Client: 503 Not Ready
 ```
 
-## 8. API Endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/health` | Registry self-health |
-| `GET` | `/api/external-health` | Health of all downstream services |
-| `POST` | `/api/services` | Register a new service |
-| `GET` | `/api/services` | List all registered services |
-| `GET` | `/api/service/:name` | Resolve a service URL (follows assignments) |
-| `POST` | `/api/services/assign` | Assign one service to another |
-| `POST` | `/api/services/:name/fail` | Mark a service as unhealthy |
-| `POST` | `/api/services/:name/call` | Trace a request to a service |
-| `GET` | `/api/services/:name/ready` | Check if service is ready (deps healthy) |
-| `POST` | `/api/dependencies` | Register a dependency |
-| `GET` | `/api/metrics` | Read request tracing counters |
-| `GET` | `/api/history` | Query event history (params: `service_name`, `event_type`, `limit`) |
-| `DELETE` | `/api/services/:name` | Deregister a service |
-
-## 9. Data Flow Summary
+## Data Flow
 
 ```mermaid
 flowchart TB
@@ -268,100 +154,14 @@ flowchart TB
   A -->|Query| E
 ```
 
-## 10. Caveats
+## See Also
 
-At the moment, there were a few items that needed to be addressed before they were going to be adopted or at least made as production-grade ready. Those are:
+For general documentation on the service registry library itself, refer to:
 
-- **No async support**. By all means, the service assignment is synchronous and resolves to the first available index. If that service is also unhealthy, no fallback will be attempted automatically
-- **Hybrid state model**. The core registry (service registrations, assignments, health status) remains in-memory for performance and it's ephemeral. However, event history is persisted to a local SQLite database that survives restarts. The two layers are intentionally separated: fast in-memory state for runtime operations, durable SQLite storage for audit and observability
-- **Single instance**. No clustering or leader election is implemented
-
-## 11. Getting Started
-
-```bash
-# Start the server
-python app.py
-
-# Register a new downstream service
-curl -X POST http://localhost:5000/api/services \
-  -H "Content-Type: application/json" \
-  -d '{"service_name": "MyAPI", "service_url": "https://api.example.com/health"}'
-
-# Assign it to a fallback
-curl -X POST http://localhost:5000/api/services/assign \
-  -H "Content-Type: application/json" \
-  -d '{"service_name": "MyAPI", "assigned_service": "V3-API-BE"}'
-
-# Trace a request
-curl -X POST http://localhost:5000/api/services/MyAPI/call
-
-# See metrics
-curl http://localhost:5000/api/metrics
-```
-
-## 12. History & Origin
-
-This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 by myself as an internal exploration into service mesh patterns and self-healing architectures.
-
-Initially, the team did not adopt Jaeger or OpenTelemetry back in 2021. However, by the end of 2023, both tracing systems were eventually adopted across the broader platform, and this experimental library was gradually shelved and postponed
-
-Fast forward to 2026: the chat services needed to become fully independent and required their own lightweight monitoring system. In June 2026, this library resurfaced. The Backend and Frontend teams decided to run live experiments with it as a dedicated health-check and service-assignment layer for the chat infrastructure, reviving the original codebase and extending it with real downstream services
-
-## 13. Production Deployment (24/7)
-
-The repository includes a Docker Compose setup designed for continuous operation.
-
-### 13.1 Docker Compose Stack
-
-| File | Purpose |
-|------|---------|
-| `Dockerfile` | Python 3.12 slim image with Gunicorn as the WSGI server. Copies `app.py`, `config.py`, `metrics.py`, `utils.py`, `services.py`, and `service_registry.py`. Installs `libsqlite3-0` as a system dependency for SQLite support |
-| `docker-compose.yml` | Orchestrates the container with restart policy and health checks |
-| `requirements.txt` | Pins Flask, Requests, and Gunicorn versions |
-| `.dockerignore` | Keeps the image lean |
-
-### 13.2 Key Production Settings
-
-- **Gunicorn** runs with 4 workers and a 120-second timeout to handle slow downstream responses.
-- **Restart policy** is set to `always` so the container recovers automatically after a host reboot or crash.
-- **Health check** pings `/api/health` every 30 seconds; Docker restarts the container if it fails 3 times in a row.
-- **Resource limits** are capped at 1 CPU and 512 MB RAM to prevent a runaway process from starving the host.
-- **Flask** runs with `debug=False` and `threaded=True` for safe concurrent request handling.
-
-### 13.3 Deploy
-
-```bash
-# Build and start
-docker compose up --build -d
-
-# View logs
-docker compose logs -f
-
-# Restart after code changes
-docker compose down && docker compose up --build -d
-```
-
-### 13.4 Monitoring
-
-Because the library is in-memory, you should monitor the host itself:
-
-- **Container uptime** via Docker health status
-- **CPU / memory** via `docker stats` or host metrics
-- **Downstream health** via the `/api/external-health` endpoint (poll every 60s)
-- **Request metrics** via `/api/metrics` (total, success, failure counts)
-
-## 14. Future Considerations
-
-This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh. Especially, the targeted environment possibly grows larger since we also need to opt-in the Chat services for other platforms
-
-| Improvement | Rationale |
-|-------------|-----------|
-| **Persistent state (partially addressed)** | Event history is now persisted via SQLite. Future work could extend persistence to service registrations and assignments using SQLite, Redis, or an external database |
-| **Async health checks** | `asyncio` or `aiohttp` to avoid blocking the GIL during slow probes |
-| **Clustering** | Multiple instances with a shared backend (for example, Consul or etcd) for high availability |
-| **Authentication** | API key or mTLS on the registry endpoints to prevent unauthorized deregistration |
-| **Prometheus metrics** | Export counters and histograms in `/metrics` format for scraping |
-| **Load balancing strategies** | Round-robin or least-latency instead of first-available assignment |
-| **Custom health thresholds** | Per-service timeout and failure-threshold configuration |
-| **Graceful shutdown** | Drain in-flight requests before stopping the health check thread |
-| **TLS termination** | Run Gunicorn with certificates instead of handling TLS inside Flask |
+- [Home](index.md) — overview and features
+- [Getting Started](getting-started.md) — installation, configuration, basic usage
+- [API Reference](api-reference.md) — all endpoints with request/response examples
+- [Configuration](configuration.md) — environment variables and settings
+- [Event History](event-history.md) — SQLite persistence internals
+- [Deployment](deployment.md) — Docker, Gunicorn, production monitoring
+- [Background & History](background.md) — project origin and philosophy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ sequenceDiagram
 
 ### 2.2 Dependencies
 
-A background daemon thread wakes up every 5 seconds and probes each registered service URL. The request includes real browser headers to bypass CloudFlare bot detection such as with user-agent or upgrade-insecure-requests.
+A dependency means a service will only be considered ready when all the services it depends on are healthy.
 
 | Service | Readiness Gate |
 |---------|-------------|
@@ -95,6 +95,20 @@ flowchart TD
   J --> B
   B -->|No| K[Wait...]
 ```
+
+## 3.1 Thread Safety
+
+Because the health check runs on a background daemon thread while API handlers run on Flask's request threads, shared mutable state needs protection from concurrent access. Every `ServiceRegistry` instance holds a single `threading.Lock` from context manager that guards:
+
+- `registered_services`: all reads, writes, and existence checks acquire the lock
+- `service_tracing`: counter updates for total, success, and failure requests
+
+The lock is acquired via the `with self._lock` context manager so it's always released, even when an exception propagates. Every public method that reads or mutates registry state follows this pattern. Apart from that, there are critical sections that required recent fixes, those are:
+
+- Look up, health check, and return now all happen inside a single critical section. Previously the return sat outside the lock, creating a race where a concurrent `deregister_service` could delete the key between the check and the access
+- The existence guard and the state mutation (`availability`, `healthy`, `failure_requests`) are now covered by the same lock. Previously only the guard was locked, leaving a race window for the mutation
+
+The `CircuitBreaker` class uses a separate dedicated lock to guard the circuit state transitions of circuit breaker alongside `failure_counts`. This is intentionally split from the registry lock to avoid unnecessary contention such as when circuit state and registry state are independent concerns
 
 ## 4. Circuit Breaker
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,7 +246,7 @@ flowchart TB
     A[Flask App]
     B[ServiceRegistryManagement]
     C[Health Check Thread]
-    E[Metrics (SQLite)]
+    E[Metrics]
   end
 
   subgraph "Downstream Services"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,299 @@
+# Service Registry Architecture
+
+This document explains the internals of the service registry library and the topology mesh that has been wired up.
+
+## 1. Overview
+
+The library implements a lightweight service registry pattern inspired by Netflix Hystrix. It provides four main building blocks:
+
+| Feature | Purpose |
+|---------|---------|
+| **Service Registration** | Register a service name → URL mapping and hold it in memory. |
+| **Service Assignment** | Route a service to another one so the caller always hits an available instance. |
+| **Health Checking** | Periodically probe each registered URL and mark it `AVAILABLE`, `STARTING`, or `DOWN`. |
+| **Circuit Breaker** | After 3 consecutive failures, open the circuit and stop hammering the unhealthy service for 5 seconds. |
+| **Request Tracing** | Count total, successful, and failed requests, and measure cumulative duration. |
+
+## 2. Topology Mesh
+
+The system is pre-registered with five downstream services. Two of them are chained together via assignments, while three others are independent. Dependencies define readiness constraints.
+
+```mermaid
+graph LR
+  subgraph "Assignment Chain"
+    A["FE-Chat-Health-Apache-Proxy<br/>(Apache Reverse Proxy)"]
+    B["FE-Chat-Health-Node-Proxy<br/>(Node.js Proxy)"]
+    C["BE-Chat-Health<br/>(Backend Chat Service)"]
+    A -- assigned to --> B
+    B -- assigned to --> C
+  end
+
+  subgraph "Independent Services"
+    D["Maukerja-Server<br/>(Main Backend API)"]
+    E["V3-API-BE<br/>(V3 API Backend)"]
+  end
+
+  subgraph "Dependencies"
+    D -- depends on --> E
+    D -- depends on --> C
+    A -- depends on --> B
+    B -- depends on --> C
+  end
+```
+
+### 2.1 Assignments
+
+Assignments create a routing chain. When you ask the registry for `FE-Chat-Health-Apache-Proxy`, it transparently returns the URL of `FE-Chat-Health-Node-Proxy`. Ask for the Node proxy and you get `BE-Chat-Health`.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Registry
+  participant Apache as FE-Chat-Health-Apache-Proxy
+  participant Node as FE-Chat-Health-Node-Proxy
+  participant Chat as BE-Chat-Health
+
+  Client->>Registry: GET /api/service/FE-Chat-Health-Apache-Proxy
+  Registry->>Apache: Resolve
+  Apache-->>Registry: assigned to Node Proxy
+  Registry->>Node: Resolve
+  Node-->>Registry: assigned to Chat
+  Registry->>Chat: Resolve
+  Chat-->>Registry: Return URL
+  Registry-->>Client: Chat Service URL
+```
+
+### 2.2 Dependencies
+
+A dependency means a service will only be considered *ready* when all the services it depends on are healthy.
+
+| Service | Readiness Gate |
+|---------|-------------|
+| `Maukerja-Server` | `V3-API-BE` AND `BE-Chat-Health` must be AVAILABLE |
+| `FE-Chat-Health-Node-Proxy` | `BE-Chat-Health` must be AVAILABLE |
+| `FE-Chat-Health-Apache-Proxy` | `FE-Chat-Health-Node-Proxy` must be AVAILABLE |
+| `BE-Chat-Health` | No dependencies (always ready if AVAILABLE) |
+| `V3-API-BE` | No dependencies (always ready if AVAILABLE) |
+
+## 3. Health Checking
+
+A background daemon thread wakes up every 5 seconds and probes each registered service URL.
+
+```mermaid
+flowchart TD
+  A[Start Health Check Thread] --> B{Is there a registered service?}
+  B -->|Yes| C[Pick next service]
+  C --> D[HTTP GET /health with browser headers]
+  D --> E{Status Code 200?}
+  E -->|Yes| F[Mark AVAILABLE + healthy=True]
+  E -->|No| G[Mark DOWN + healthy=False]
+  G --> H[Increment failure_requests]
+  F --> I{More services?}
+  G --> I
+  I -->|Yes| C
+  I -->|No| J[Sleep 5 seconds]
+  J --> B
+  B -->|No| K[Wait...]
+```
+
+The request includes real browser headers to bypass CloudFlare bot detection (User-Agent, Accept, Sec-Fetch-*, etc.).
+
+## 4. Circuit Breaker
+
+Every health check call is wrapped in a circuit breaker with:
+
+- **Threshold:** 3 consecutive failures before opening the circuit
+- **Timeout:** 5 seconds in OPEN state before trying again (HALF_OPEN)
+
+```mermaid
+stateDiagram-v2
+  [*] --> CLOSED
+  CLOSED --> OPEN : 3 failures
+  OPEN --> HALF_OPEN : after 5s timeout
+  HALF_OPEN --> CLOSED : 1 success
+  HALF_OPEN --> OPEN : failure
+  CLOSED --> CLOSED : success
+```
+
+When the circuit is **OPEN**, any further request returns `None` immediately without touching the network. This prevents cascading overload on an already failing downstream.
+
+## 5. Request Tracing
+
+When you simulate a call with `POST /api/services/<name>/call`, the registry increments global counters:
+
+- `total_requests`
+- `successful_requests` (always true for simulation)
+- `failure_requests`
+- `duration` (cumulative)
+
+```mermaid
+flowchart LR
+  A[Client] -->|POST /call| B[Service Registry]
+  B --> C[Trace Service Request]
+  C --> D[total_requests += 1]
+  C --> E[successful_requests += 1]
+  C --> F[duration += 0.5s]
+  B -->|200 OK| G[Metrics Updated]
+```
+
+## 6. Simulating Failures
+
+You can force a service into the `DOWN` state with `POST /api/services/<name>/fail`.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Registry
+  participant Downstream
+
+  Client->>Registry: POST /api/services/Maukerja-Server/fail
+  Registry->>Registry: Mark as DOWN + healthy=False
+  Registry-->>Client: 200 OK
+  Client->>Registry: GET /api/services/Maukerja-Server/ready
+  Registry->>Registry: Check dependencies
+  Registry-->>Client: 503 Not Ready
+```
+
+This is useful for testing how upstream services react when a downstream dependency disappears.
+
+## 7. API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/health` | Registry self-health |
+| `GET` | `/api/external-health` | Health of all downstream services |
+| `POST` | `/api/services` | Register a new service |
+| `GET` | `/api/services` | List all registered services |
+| `GET` | `/api/service/:name` | Resolve a service URL (follows assignments) |
+| `POST` | `/api/services/assign` | Assign one service to another |
+| `POST` | `/api/services/:name/fail` | Mark a service as unhealthy |
+| `POST` | `/api/services/:name/call` | Trace a request to a service |
+| `GET` | `/api/services/:name/ready` | Check if service is ready (deps healthy) |
+| `POST` | `/api/dependencies` | Register a dependency |
+| `GET` | `/api/metrics` | Read request tracing counters |
+| `DELETE` | `/api/services/:name` | Deregister a service |
+
+## 8. Data Flow Summary
+
+```mermaid
+flowchart TB
+  subgraph "Application"
+    A[Flask App]
+    B[ServiceRegistryManagement]
+    C[Health Check Thread]
+  end
+
+  subgraph "Downstream Services"
+    D1["Maukerja-Server"]
+    D2["V3-API-BE"]
+    D3["BE-Chat-Health"]
+    D4["FE-Chat-Health-Node-Proxy"]
+    D5["FE-Chat-Health-Apache-Proxy"]
+  end
+
+  A -->|Register / Assign / Depend| B
+  C -->|HTTP GET every 5s| D1
+  C -->|HTTP GET every 5s| D2
+  C -->|HTTP GET every 5s| D3
+  C -->|HTTP GET every 5s| D4
+  C -->|HTTP GET every 5s| D5
+  B -->|Metrics| A
+```
+
+## 9. Caveats
+
+- **In-memory only.** All state is lost when the process restarts.
+- **Synchronous.** Service resolution and health checks are single-threaded per service.
+- **No persistence.** There is no database or external storage.
+- **Single instance.** No clustering or leader election is implemented.
+
+## 10. Getting Started
+
+```bash
+# Start the server
+python app.py
+
+# Register a new downstream service
+curl -X POST http://localhost:5000/api/services \
+  -H "Content-Type: application/json" \
+  -d '{"service_name": "MyAPI", "service_url": "https://api.example.com/health"}'
+
+# Assign it to a fallback
+curl -X POST http://localhost:5000/api/services/assign \
+  -H "Content-Type: application/json" \
+  -d '{"service_name": "MyAPI", "assigned_service": "V3-API-BE"}'
+
+# Trace a request
+curl -X POST http://localhost:5000/api/services/MyAPI/call
+
+# See metrics
+curl http://localhost:5000/api/metrics
+```
+
+## 11. History & Origin
+
+This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 by the original author as an internal exploration into service mesh patterns and self-healing architectures.
+
+Initially, the team did not adopt Jaeger or OpenTelemetry back in 2021. However, by the end of 2023, both tracing systems were eventually adopted across the broader platform, and this experimental library was gradually shelved and postponed.
+
+Fast forward to 2026: the chat services needed to become fully independent and required their own lightweight monitoring system. In June 2026, this library resurfaced. The Backend and Frontend teams decided to run live experiments with it as a dedicated health-check and service-assignment layer for the chat infrastructure, reviving the original codebase and extending it with real downstream services.
+
+## 12. Production Deployment (24/7)
+
+The repository includes a Docker Compose setup designed for continuous operation.
+
+### 12.1 Docker Compose Stack
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Python 3.12 slim image with Gunicorn as the WSGI server |
+| `docker-compose.yml` | Orchestrates the container with restart policy and health checks |
+| `requirements.txt` | Pins Flask, Requests, and Gunicorn versions |
+| `.dockerignore` | Keeps the image lean |
+
+### 12.2 Key Production Settings
+
+- **Gunicorn** runs with 4 workers and a 120-second timeout to handle slow downstream responses.
+- **Restart policy** is set to `always` so the container recovers automatically after a host reboot or crash.
+- **Health check** pings `/api/health` every 30 seconds; Docker restarts the container if it fails 3 times in a row.
+- **Resource limits** are capped at 1 CPU and 512 MB RAM to prevent a runaway process from starving the host.
+- **Flask** runs with `debug=False` and `threaded=True` for safe concurrent request handling.
+
+### 12.3 Deploy
+
+```bash
+# Build and start
+docker compose up --build -d
+
+# View logs
+docker compose logs -f
+
+# Restart after code changes
+docker compose down && docker compose up --build -d
+```
+
+### 12.4 Monitoring
+
+Because the library is in-memory, you should monitor the host itself:
+
+- **Container uptime** via Docker health status
+- **CPU / memory** via `docker stats` or host metrics
+- **Downstream health** via the `/api/external-health` endpoint (poll every 60s)
+- **Request metrics** via `/api/metrics` (total, success, failure counts)
+
+## 13. Future Considerations
+
+This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh:
+
+| Improvement | Rationale |
+|-------------|-----------|
+| **Persistent state** | SQLite or Redis so registrations and assignments survive restarts |
+| **Async health checks** | `asyncio` or `aiohttp` to avoid blocking the GIL during slow probes |
+| **Clustering** | Multiple instances with a shared backend (e.g., Consul, etcd) for high availability |
+| **Authentication** | API key or mTLS on the registry endpoints to prevent unauthorized deregistration |
+| **Prometheus metrics** | Export counters and histograms in `/metrics` format for scraping |
+| **Load balancing strategies** | Round-robin or least-latency instead of first-available assignment |
+| **Custom health thresholds** | Per-service timeout and failure-threshold configuration |
+| **Webhook notifications** | Alert Slack / PagerDuty when a downstream service goes DOWN |
+| **Graceful shutdown** | Drain in-flight requests before stopping the health check thread |
+| **TLS termination** | Run Gunicorn with certificates instead of handling TLS inside Flask |

--- a/docs/background.md
+++ b/docs/background.md
@@ -1,0 +1,81 @@
+# Background & History
+
+## Origin (2023)
+
+This library was initially built as part of the research and development team's effort to implement distributed tracing, alongside tools like Jaeger and OpenTelemetry. Development began in 2023 as an internal exploration into service mesh patterns and self-healing architectures.
+
+At the time, the broader platform was evaluating observability tooling:
+
+- **2021:** Jaeger and OpenTelemetry were discussed but not adopted
+- **2023:** Both tracing systems were eventually adopted across the platform
+- **2023:** This experimental library was shelved as the platform moved to production-grade tracing solutions
+
+## Resurrection (2026)
+
+Fast forward to June 2026. The chat services needed to become fully independent and required their own lightweight monitoring system, something more targeted than the full OpenTelemetry stack for a focused use case.
+
+The library resurfaced when:
+
+- The **Backend** and **Frontend** teams needed a dedicated health-check and service-assignment layer for the chat infrastructure
+- The existing tracing infrastructure was too heavy for the chat team's requirements
+- A lightweight, in-process registry could run alongside the chat services without additional infrastructure
+
+The original codebase was revived, extended with real downstream services, and wired into production chat infrastructure.
+
+## Architecture Considerations
+
+The library follows a deliberately **lightweight** approach:
+
+### Why In-Memory?
+
+The core registry state is kept in memory for speed:
+
+- **No database round-trips** for registration lookups and health checks
+- **No schema migrations** to manage
+- **Instant restart** just re-register services and resume operations
+
+### Why SQLite for Store Events?
+
+Events need to survive restarts for audit and debugging purposes:
+
+- **Embedded**: no separate database server to maintain
+- **Zero-configuration**: the database file is created automatically
+- **WAL mode**: readers never block writers, writers never block readers
+- **Thread-safe**: dedicated lock serialises writes, indexes speed up queries
+
+### Why Not a Full Service Mesh?
+
+Not every distributed system needs Istio or Linkerd. For our cases, teams that need:
+
+- A single focused feature (health checking with circuit breaking)
+- Minimal operational overhead (one container, one process)
+- Fast iteration (no CRD definitions, no sidecar injection, no control plane)
+
+...this library provides the essential patterns without the complexity overhead of a full service mesh. It is not meant to replace those tools but to serve as a lightweight alternative for specific use cases
+
+## Inspiration
+
+The design is heavily inspired by:
+
+- **[Netflix Hystrix](https://github.com/Netflix/Hystrix)** — Circuit breaker patterns and fault isolation
+- **[Microservices Patterns](https://microservices.io/patterns/index.html)** — Service registry, circuit breaker, and health check patterns from Chris Richardson's catalog
+
+## Current Status
+
+The library is running as a **live experiment** in production for the chat infrastructure as of June 2026. It is intentionally kept small and focused, with the understanding that it may be replaced by more robust infrastructure as requirements grow.
+
+## Future Considerations
+
+This library is intentionally lightweight, but several enhancements would make it production-grade for a larger mesh. Especially, the targeted environment possibly grows larger since we also need to opt-in the Chat services for other platforms
+
+| Improvement | Rationale |
+|-------------|-----------|
+| **Persistent state (partially addressed)** | Event history is now persisted via SQLite. Future work could extend persistence to service registrations and assignments using SQLite, Redis, or an external database |
+| **Async health checks** | `asyncio` or `aiohttp` to avoid blocking the GIL during slow probes |
+| **Clustering** | Multiple instances with a shared backend (for example, Consul or etcd) for high availability |
+| **Authentication** | API key or mTLS on the registry endpoints to prevent unauthorized deregistration |
+| **Prometheus metrics** | Export counters and histograms in `/metrics` format for scraping |
+| **Load balancing strategies** | Round-robin or least-latency instead of first-available assignment |
+| **Custom health thresholds** | Per-service timeout and failure-threshold configuration |
+| **Graceful shutdown** | Drain in-flight requests before stopping the health check thread |
+| **TLS termination** | Run Gunicorn with certificates instead of handling TLS inside Flask |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,104 @@
+# Configuration
+
+The service registry is configured through a combination of environment variables and a `config.py` module.
+
+## Environment Variables (`.env`)
+
+The application loads configuration from a `.env` file via `python-dotenv`. Each variable is the URL of a downstream service that the registry will pre-register and monitor. As for example just like in the [architecture](architecture.md) documentation, the registry will monitor the health of the main MauKerja chat service and such, so the required environment variables are:
+
+### Required Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MAUKERJA_SERVER` | URL of the main MauKerja backend API health endpoint |
+| `V3_API_BE` | URL of the V3 API backend health endpoint |
+| `BE_CHAT_HEALTH` | URL of the backend chat service health endpoint |
+| `FE_CHAT_HEALTH_NODE_PROXY` | URL of the Node.js proxy health endpoint |
+| `FE_CHAT_HEALTH_APACHE_PROXY` | URL of the Apache reverse proxy health endpoint |
+
+### Example configuration in `.env`
+
+```bash
+MAUKERJA_SERVER=https://maukerja.example.com/health
+V3_API_BE=https://v3-api.example.com/health
+BE_CHAT_HEALTH=https://chat.example.com/health
+FE_CHAT_HEALTH_NODE_PROXY=https://node-proxy.example.com/health
+FE_CHAT_HEALTH_APACHE_PROXY=https://apache-proxy.example.com/health
+```
+
+!!! warning
+    Make sure to replace the example URLs with the actual service endpoints you want to monitor. The registry will attempt to register these services on startup and perform health checks against them.
+
+## `config.py`
+
+The `config.py` module loads the environment variables and defines two key exports:
+
+### `DEFAULT_HEADERS`
+
+A dictionary of HTTP headers used for health-check requests. These mimic a real browser to bypass CloudFlare bot protection:
+
+```python
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) ...",
+    "Accept": "text/html,application/xhtml+xml,...",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Upgrade-Insecure-Requests": "1",
+}
+```
+
+!!! tip
+    If your downstream services use a different protection mechanism, you can modify these headers in `config.py` or pass custom headers via the `check_downstream_health()` utility function.
+
+### `DOWNSTREAM_SERVICES`
+
+A dictionary mapping service names to their URLs, populated from environment variables:
+
+```python
+DOWNSTREAM_SERVICES = {
+    "Maukerja-Server": os.getenv("MAUKERJA_SERVER"),
+    "V3-API-BE": os.getenv("V3_API_BE"),
+    "BE-Chat-Health": os.getenv("BE_CHAT_HEALTH"),
+    "FE-Chat-Health-Node-Proxy": os.getenv("FE_CHAT_HEALTH_NODE_PROXY"),
+    "FE-Chat-Health-Apache-Proxy": os.getenv("FE_CHAT_HEALTH_APACHE_PROXY"),
+}
+```
+
+## Runtime Configuration
+
+### Health Check Interval
+
+The background health-check thread runs every **5 seconds** by default. This is defined in `ServiceRegistry.health_check_interval` and can be changed at runtime:
+
+```python
+registry.health_check_interval = 10  # every 10 seconds
+```
+
+### Circuit Breaker Settings
+
+The `CircuitBreaker` class accepts two parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `threshold` | 3 | Consecutive failures before the circuit opens |
+| `timeout` | 5 | Seconds to stay in OPEN state before transitioning to HALF_OPEN |
+
+These thresholds are applied per-service via the `@circuit_breaker` decorator in `_simulate_health_check()`.
+
+### SQLite Database
+
+The event history is stored in a local SQLite database:
+
+| Setting | Value |
+|---------|-------|
+| **File path** | `metrics_history.db` (in the working directory) |
+| **Journal mode** | WAL (Write-Ahead Logging) |
+| **Write lock** | `threading.Lock` for serialised inserts |
+| **Table** | `service_events` |
+
+The database file is created automatically on first import of `metrics.py`. You can change the path by modifying the `DB_PATH` variable in `metrics.py`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,92 @@
+# Deployment
+
+The repository includes everything needed for 24/7 production deployment using Docker and Gunicorn.
+
+## Production Stack
+
+| Component | Technology |
+|-----------|------------|
+| **Application server** | Gunicorn (WSGI) |
+| **Web framework** | Flask |
+| **Container runtime** | Docker + Docker Compose |
+| **Event storage** | SQLite (embedded, file-based) |
+
+## Dockerfile
+
+The `Dockerfile` builds a Python 3.12 slim image:
+
+- Installs system dependencies: `libsqlite3-0` (for SQLite support) and `curl` (for health checks)
+- Copies application code: `app.py`, `config.py`, `metrics.py`, `utils.py`, `services.py`, `service_registry.py`
+- Runs Gunicorn with 4 workers and a 120-second timeout
+
+```dockerfile
+--8<-- "Dockerfile"
+```
+
+## Docker Compose
+
+The `docker-compose.yml` orchestrates the container with production-grade settings:
+
+### Key Settings
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| **Restart policy** | `always` | Auto-recover after host reboot or crash |
+| **Health check** | `curl http://localhost:5000/api/health` every 30s, 3 retries | Docker restarts if unhealthy |
+| **CPU limit** | 1.0 core | Prevent runaway process from starving the host |
+| **Memory limit** | 512 MB | Hard cap on memory usage |
+| **CPU reservation** | 0.25 cores | Guaranteed minimum CPU |
+| **Memory reservation** | 128 MB | Guaranteed minimum memory |
+
+```yaml
+--8<-- "docker-compose.yml"
+```
+
+## Deploying
+
+### Build and Start
+
+```bash
+docker compose up --build -d
+```
+
+### View Logs
+
+```bash
+docker compose logs -f
+```
+
+### Restart After Code Changes
+
+```bash
+docker compose down && docker compose up --build -d
+```
+
+### Using Makefile
+
+```bash
+make build    # docker compose build
+make run      # docker compose up -d
+make stop     # docker compose down
+make logs     # docker compose logs -f
+```
+
+## Monitoring
+
+Because the core registry state is in-memory, monitoring the host system is important:
+
+| What to Monitor | How |
+|----------------|-----|
+| **Container uptime** | Docker health status (`docker ps`) |
+| **CPU / memory** | `docker stats` or host-level metrics |
+| **Downstream health** | Poll `/api/external-health` every 60s |
+| **Request metrics** | Poll `/api/metrics` for total/success/failure counts |
+| **Event history** | Poll `/api/history` for audit trail |
+
+## Caveats
+
+While this stack is production-ready for a lightweight service registry, it has limitations that may require future enhancements:
+
+- **No async support.** Service assignment is synchronous and resolves to the first available index. No automatic fallback.
+- **Hybrid state model.** Core state (registrations, assignments, health) is in-memory and ephemeral. Only event history is persisted to SQLite.
+- **Single instance.** No clustering or leader election is implemented.

--- a/docs/event-history.md
+++ b/docs/event-history.md
@@ -1,0 +1,150 @@
+# Event History (SQLite Persistence)
+
+The service registry keeps its core state (registrations, assignments, health status) **in memory** for performance. But in-memory state vanishes on restart. To preserve an audit trail, every meaningful operation also writes to a local SQLite database via `metrics.py`.
+
+## How It Works
+
+Each public operation that mutates registry state triggers a single `INSERT` into the `service_events` table. The row stores:
+
+- A Unix epoch **timestamp**
+- The **service name**
+- An **event type** string
+- A free-text **detail** field
+
+Because SQLite is embedded, the database file lives alongside the application thus no separate server process required. Here's how the event recording flow works:
+
+```mermaid
+sequenceDiagram
+    participant Client as HTTP Client
+    participant Flask as Flask API
+    participant Registry as ServiceRegistry
+    participant Metrics as metrics.py
+    participant DB as metrics_history.db
+
+    Client->>Flask: POST /api/services (register)
+    Flask->>Registry: register_services()
+    Registry->>Metrics: record_event("service_registered")
+    Metrics->>DB: INSERT with WAL mode
+    DB-->>Metrics: OK
+    Metrics-->>Registry: done
+    Registry-->>Flask: return
+    Flask-->>Client: 201 Created
+
+    Client->>Flask: GET /api/history
+    Flask->>Metrics: get_events(service_name, event_type, limit)
+    Metrics->>DB: SELECT with filters
+    DB-->>Metrics: rows
+    Metrics-->>Flask: events list
+    Flask-->>Client: JSON array
+```
+
+## Transaction Safety
+
+SQLite itself is thread-safe for reads, but concurrent writes can deadlock or corrupt the journal if multiple threads commit at the exact same moment. To avoid this:
+
+- All write paths acquire a dedicated **`threading.Lock`** before opening a connection
+- This serialises inserts so only one thread can commit at a time
+- The `record_event()` function always acquires the lock before connecting
+
+### WAL Mode
+
+The database is opened in **WAL (Write-Ahead Logging)** mode. WAL allows readers to proceed while a writer is appending to the log, so the `GET /api/history` endpoint never blocks on an active `record_event()` call.
+
+```python
+@contextmanager
+def _init_connection():
+    connection = sqlite3.connect(DB_PATH, timeout=10)
+    try:
+        connection.execute("PRAGMA journal_mode=WAL")
+        yield connection
+    finally:
+        connection.close()
+```
+
+## Event Types
+
+| Event Type | Triggered By | Detail Example |
+|---|---|---|
+| `service_registered` | `register_services()` | URL of the registered service |
+| `service_deregistered` | `deregister_service()` | Name of the deregistered service |
+| `service_assigned` | `assign_service()` | `"ServiceA assigned to ServiceB"` |
+| `service_failure` | `simulate_service_is_unhealthy()` | `"simulated failure"` (only on state transition) |
+| `request_traced` | `trace_service_request()` | Name of the traced service |
+| `dependency_registered` | `register_dependency()` | `"ServiceA depends on ServiceB"` |
+| `health_check_healthy` | `_simulate_health_check()` | `"state changed to AVAILABLE"` (only on transition) |
+| `health_check_unhealthy` | `_simulate_health_check()` | `"state changed to DOWN"` (only on transition) |
+
+!!! note "Health Check Events"
+    Health check events fire **only on state transitions** — not on every 5-second poll. This prevents flooding the database when a service is consistently healthy or unhealthy.
+
+## Querying Events
+
+### Via API
+
+```bash
+# All events (most recent first, max 100)
+curl http://localhost:5000/api/history
+
+# Filter by service
+curl "http://localhost:5000/api/history?service_name=MyAPI"
+
+# Filter by event type
+curl "http://localhost:5000/api/history?event_type=service_failure"
+
+# Limit results
+curl "http://localhost:5000/api/history?limit=5"
+
+# Combined filters
+curl "http://localhost:5000/api/history?service_name=MyAPI&event_type=health_check_healthy&limit=10"
+```
+
+### Response Format
+
+```json
+[
+  {
+    "timestamp": 1718000000.123,
+    "service_name": "MyAPI",
+    "event_type": "service_registered",
+    "detail": "https://api.example.com/health"
+  }
+]
+```
+
+## Database Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS service_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL NOT NULL,
+    service_name TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    detail TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_events_service_name
+    ON service_events (service_name);
+
+CREATE INDEX IF NOT EXISTS idx_service_events_event_type
+    ON service_events (event_type);
+
+CREATE INDEX IF NOT EXISTS idx_service_events_timestamp
+    ON service_events (timestamp);
+```
+
+The three indexes ensure efficient filtering by `service_name`, `event_type`, and ordering by `timestamp`.
+
+## Hybrid State Model
+
+The architecture intentionally separates two storage layers:
+
+| Layer | Storage | Characteristics |
+|-------|---------|-----------------|
+| **Core state** | In-memory (`dict`) | Fast reads/writes, ephemeral, reset-friendly |
+| **Event history** | SQLite (`metrics_history.db`) | Durable, survives restarts, queryable via API |
+
+This means:
+
+- **Registrations, assignments, health status** are lost on restart (fast, no I/O)
+- **Event audit trail** persists (every operation is logged to disk)
+- The two layers are independent, neither blocks the other

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,189 @@
+# Getting Started
+
+## Installation
+
+### Prerequisites
+
+- Python 3.10+
+- pip
+- (Optional) Docker and Docker Compose for containerized deployment
+
+### Clone the Repository
+
+This library is not published on PyPI, so you'll need to clone it directly:
+
+```bash
+git clone https://github.com/sodrooome/service-registry.git
+cd service-registry
+```
+
+### Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+The `requirements.txt` pins four critical dependencies for the service registry:
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `Flask` | >=2.0.0 | Web framework for the REST API |
+| `requests` | >=2.28.0 | HTTP client for health-check probes |
+| `gunicorn` | >=21.0.0 | Production WSGI server |
+| `python-dotenv` | 1.2.2 | Load `.env` files for configuration |
+
+## Configuration
+
+After installing dependencies, you need to tell the service registry which downstream services to monitor.
+
+### Option A: Using a `.env` file (recommended)
+
+Create a `.env` file in the project root. It's already ignored in `.gitignore`, so secrets stay local:
+
+```bash
+touch .env
+```
+
+Add your actual service URLs:
+
+```bash
+MAUKERJA_SERVER=https://your-api.example.com/health
+V3_API_BE=https://v3-api.example.com/health
+BE_CHAT_HEALTH=https://chat.example.com/health
+FE_CHAT_HEALTH_NODE_PROXY=https://node-proxy.example.com/health
+FE_CHAT_HEALTH_APACHE_PROXY=https://apache-proxy.example.com/health
+```
+
+These map directly to the `DOWNSTREAM_SERVICES` dictionary in [`config.py`](./configuration.md).
+
+### Option B: Hardcoded URLs directly in `config.py`
+
+If you prefer not to use a `.env` file, open [`config.py`](https://github.com/sodrooome/service-registry/blob/main/config.py) and replace the environment variable lookups with your actual URLs:
+
+```python
+DOWNSTREAM_SERVICES = {
+    "My-Service-Name": "https://my-service.example.com/health",
+    "Another-Service": "https://another-service.example.com/health",
+}
+```
+
+You can add, remove, or rename services here as needed. The service name you choose will be used throughout the API or when you interact with the registry endpoints.
+
+### Customising Assignments & Dependencies
+
+Once your services are configured, open [`services.py`](https://github.com/sodrooome/service-registry/blob/main/services.py). This file wires everything together at startup:
+
+1. **Service Registration**. Each service from `DOWNSTREAM_SERVICES` is registered automatically in the downstream service loop.
+
+2. **Service Assignment**. Use assign service method from the core registry module to chain services. For example, if `Frontend-Proxy` should route to `Backend-API`:
+
+    ```python
+    registry.assign_service(
+        service_name="Frontend-Proxy",
+        assigned_service_name="Backend-API",
+    )
+    ```
+
+    When you resolve `Frontend-Proxy` via the API, it will return `Backend-API`'s URL instead.
+
+3. **Dependencies**. Use register dependencies method to define readiness gates. A service is only "ready" when all its dependencies are healthy:
+
+    ```python
+    registry.register_dependency(
+        service_name="Frontend-Proxy",
+        depends_on="Backend-API",
+    )
+    ```
+
+    You can add multiple dependencies for the same service:
+
+    ```python
+    registry.register_dependency(
+        service_name="Main-Backend",
+        depends_on="Database-API",
+    )
+    registry.register_dependency(
+        service_name="Main-Backend",
+        depends_on="Cache-Service",
+    )
+    ```
+
+!!! tip
+    Edit `services.py` to reflect your actual topology. The MauKerja chat services in the file are just examples. Replace them with your own service names, assignments, and dependencies.
+
+## Running the Server
+
+### Development (Flask built-in server)
+
+```bash
+python app.py
+```
+
+The server starts on `http://0.0.0.0:5000` by default.
+
+### Production (Gunicorn)
+
+```bash
+gunicorn --bind 0.0.0.0:5000 --workers 4 --timeout 120 app:app
+```
+
+## Running Standalone (Without Flask)
+
+You can also run the service registry logic directly without the Flask API:
+
+```bash
+python service_registry.py
+```
+
+This runs the built-in demo that registers mock services from `config.py`, performs assignments, and prints live log output.
+
+## Basic Usage
+
+### Register a Service
+
+```bash
+curl -X POST http://localhost:5000/api/services \
+  -H "Content-Type: application/json" \
+  -d '{"service_name": "MyAPI", "service_url": "https://api.example.com/health"}'
+```
+
+### List All Services
+
+```bash
+curl http://localhost:5000/api/services
+```
+
+### Resolve a Service URL
+
+```bash
+curl http://localhost:5000/api/service/MyAPI
+```
+
+### Simulate a Failure
+
+```bash
+curl -X POST http://localhost:5000/api/services/MyAPI/fail
+```
+
+### Check Event History
+
+```bash
+curl http://localhost:5000/api/history
+```
+
+### View Tracing Metrics
+
+```bash
+curl http://localhost:5000/api/metrics
+```
+
+## Run with Makefile
+
+A `Makefile` is provided for convenience to spin up the server using Docker compose stack
+
+```bash
+make build   # docker compose build
+make run     # docker compose up -d
+make stop    # docker compose down
+make logs    # docker compose logs -f
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,73 @@
+# Service Registry
+
+A lightweight service registry library that implements a service registry pattern with circuit breaker, health checking, request tracing, and persistent event history. It is designed to be embedded in any **platform agnostic application** and provides a simple API for registering services, defining dependencies, and simulating service interactions.
+
+## What is it?
+
+This library provides a lightweight, embeddable service registry for **simulating and managing distributed service interactions**. It was designed to help teams:
+
+- **Simulate** third-party service calls in a controlled environment
+- **Self-register** failing services to available alternatives
+- **Isolate** failure domains so one broken service doesn't cascade
+- **Trace** request metrics across all registered services
+- **Persist** an audit trail of every registry event to SQLite
+
+## Core Features
+
+| Feature | Description |
+|---------|-------------|
+| **Service Registration** | Register services with name-to-URL mappings, held in memory for fast access |
+| **Service Assignment** | Route one service to another so callers always hit an available instance |
+| **Health Checking** | Background daemon thread probes every registered URL every 5 seconds with browser-grade headers |
+| **Circuit Breaker** | After 3 consecutive failures, the circuit opens and stops requests for 5 seconds |
+| **Request Tracing** | Count total, successful, and failed requests; measure cumulative duration |
+| **Dependency Readiness** | Define service dependencies such as a service is "ready" only when all its dependencies are healthy |
+| **Event History** | All registrations, failures, assignments, health transitions, and traces are recorded in SQLite and queryable via API |
+| **Thread Safety** | `threading.Lock` guards all shared mutable state across health-check and request threads |
+
+## How It Works
+
+```mermaid
+flowchart TB
+  subgraph "Application"
+    A[Flask API]
+    B[ServiceRegistry]
+    C[Health Check Thread]
+    E[SQLite Event Store]
+  end
+
+  subgraph "Downstream Services"
+    D1["Service A"]
+    D2["Service B"]
+    D3["Service C"]
+  end
+
+  A -->|Register / Assign / Depend| B
+  C -->|HTTP GET every 5s| D1
+  C -->|HTTP GET every 5s| D2
+  C -->|HTTP GET every 5s| D3
+  B -->|Event History| E
+  A -->|Query| E
+```
+
+## Quick Start
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Start the server
+python app.py
+
+# Register a service
+curl -X POST http://localhost:5000/api/services \
+  -H "Content-Type: application/json" \
+  -d '{"service_name": "MyAPI", "service_url": "https://api.example.com/health"}'
+
+# Check event history
+curl http://localhost:5000/api/history
+```
+
+## Inspiration
+
+This library follows the microservices patterns described in the [microservices.io](https://microservices.io/patterns/index.html) catalog and is functionally inspired by Netflix Hystrix. While it does not cover every Hystrix feature, it captures the essential behaviour of **fault isolation** and **graceful degradation** in a lightweight, zero-dependency package.

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,102 @@
+"""
+Lightweight SQLite store for service registry management events
+
+This is intended separating between service registry which used in-memory state and Flask's service
+- core service registry stays in-memory since it's fast, ephemeral and reset friendly
+- while this module will persist a history of what have happened regarding failures/success metrics
+"""
+
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+
+# by default set this name
+DB_PATH = "metrics_history.db"
+DB_SCHEMA = """CREATE TABLE IF NOT EXISTS service_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL NOT NULL,
+    service_name TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    detail TEXT
+);
+ 
+CREATE INDEX IF NOT EXISTS idx_service_events_service_name
+    ON service_events (service_name);
+ 
+CREATE INDEX IF NOT EXISTS idx_service_events_event_type
+    ON service_events (event_type);
+ 
+CREATE INDEX IF NOT EXISTS idx_service_events_timestamp
+    ON service_events (timestamp);
+"""
+
+# allow concurrent reads but only single writes
+_write_lock = threading.Lock()
+
+
+@contextmanager
+def _init_connection():
+    conection = sqlite3.connect(DB_PATH, timeout=10)
+    try:
+        # enables WAL mode so it can performed concurrently
+        conection.execute("PRAGMA journal_mode=WAL")
+        yield conection
+    finally:
+        conection.close()
+
+
+def init_database() -> None:
+    with _write_lock, _init_connection() as conn:
+        conn.executescript(DB_SCHEMA)
+        conn.commit()
+
+
+init_database()
+
+
+def record_event(service_name: str, event_type: str, detail: str) -> None:
+    with _write_lock, _init_connection() as conn:
+        conn.execute(
+            "INSERT INTO service_events (timestamp, service_name, event_type, detail) "
+            "VALUES (?, ?, ?, ?)",
+            (time.time(), service_name, event_type, detail),
+        )
+        conn.commit()
+
+
+def get_events(service_name: str, event_type: str, limit: int = 100) -> list:
+    """Read events based on the recent first"""
+    query = "SELECT timestamp, service_name, event_type, detail FROM service_events"
+    conditions = []
+    params = []
+
+    if service_name:
+        conditions.append("service_name = ?")
+        params.append(service_name)
+
+    if event_type:
+        conditions.append("event_type = ?")
+        params.append(event_type)
+
+    if conditions:
+        query += " WHERE " + " AND ".join(conditions)
+
+    query += " ORDER BY id DESC LIMIT ?"
+    params.append(limit)
+
+    with _init_connection() as conn:
+        cursor = conn.execute(query, params)
+        rows = cursor.fetchall()
+
+    events = []
+    for row in rows:
+        events.append(
+            {
+                "timestamp": row[0],
+                "service_name": row[1],
+                "event_type": row[2],
+                "detail": row[3],
+            }
+        )
+    return events

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: Service Registry Documentation
+site_description: Lightweight service registry with circuit breaker, health checking, request tracing, and SQLite-persisted event history
+repo_url: https://github.com/sodrooome/service-registry
+repo_name: sodrooome/service-registry
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.keys
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/sodrooome/service-registry
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - API Reference: api-reference.md
+  - Configuration: configuration.md
+  - Event History: event-history.md
+  - Deployment: deployment.md
+  - Background & History: background.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.0.0
+requests>=2.28.0
+gunicorn>=21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.0.0
 requests>=2.28.0
 gunicorn>=21.0.0
+python-dotenv==1.2.2

--- a/service_registry.py
+++ b/service_registry.py
@@ -7,11 +7,11 @@ import typing
 from config import DEFAULT_HEADERS
 
 
-class CircuitBreakerException(BaseException):
+class CircuitBreakerException(Exception):
     """Exception that arises when remote call is failed"""
 
 
-class RequestCallException(BaseException):
+class RequestCallException(Exception):
     """Exception that arises when request is failed"""
 
 
@@ -38,7 +38,7 @@ class CircuitBreaker:
 
     def open(self) -> None:
         self.state = CircuitBreakerState.OPEN
-        self.last_time_of_failure = self.timestamp
+        self.last_time_of_failure = time.time()
 
     def close(self) -> None:
         self.state = CircuitBreakerState.CLOSED
@@ -51,12 +51,13 @@ class CircuitBreaker:
         return self.failure_counts >= self.threshold
 
     def handle_reset_state(self) -> typing.Any:
-        return self.timestamp - self.last_time_of_failure >= self.timeout
+        return time.time() - self.last_time_of_failure >= self.timeout
 
     def make_remote_call(self, func) -> typing.Any:
         if self.state == CircuitBreakerState.OPEN:
             if not self.handle_reset_state():
                 return None
+            self.half_open()  # transition to half open state to test the remote call
 
         try:
             result_value = func()
@@ -188,7 +189,7 @@ class ServiceRegistry:
         # currently, this function would be picked
         # the available service based on the first index
         if available_services:
-            return self._get_service_name_url(available_services)
+            return self._get_service_name_url(available_services[0])
 
         return None
 
@@ -233,7 +234,7 @@ class ServiceRegistry:
             self.registered_services[service_name]["healthy"] = False
             self.service_tracing["failure_requests"] += 1
             self.log(f"Related service is unhealthy due to error: {e}")
-            return False
+            raise
         return False
 
     def assign_service(self, service_name: str, assigned_service_name: str) -> None:
@@ -328,9 +329,9 @@ class ServiceRegistryManagement(ServiceRegistry):
         return all(self.get_available_services(dep) for dep in dependencies)
 
     def wait_for_dependencies(self, service_name: str, timeout: int = 30) -> bool:
-        start_time = self.timestamp
+        start_time = time.time()
         while not self.is_service_ready(service_name):
-            if self.timestamp - start_time > timeout:
+            if time.time() - start_time > timeout:
                 return False
             # for now just align the sleep interval with the health check
             time.sleep(self.health_check_interval)

--- a/service_registry.py
+++ b/service_registry.py
@@ -223,6 +223,7 @@ class ServiceRegistry:
                     "availability"
                 ] = ServiceRegistryState.AVAILABLE
                 self.registered_services[service_name]["healthy"] = True
+                self.service_tracing["successful_requests"] += 1
                 self.log("Related service is healthy")
                 return True
         except requests.exceptions.RequestException as e:
@@ -279,7 +280,7 @@ class ServiceRegistry:
         return services_result
 
     def trace_service_request(self, service_name: str) -> None:
-        start_time = self.timestamp
+        start_time = time.time()
 
         if service_name not in self.registered_services:
             raise ValueError(
@@ -294,7 +295,7 @@ class ServiceRegistry:
             success = False
             raise RequestCallException
         finally:
-            end_time = self.timestamp
+            end_time = time.time()
             duration = end_time - start_time
 
             self.service_tracing["total_requests"] += 1

--- a/service_registry.py
+++ b/service_registry.py
@@ -36,6 +36,9 @@ class CircuitBreaker:
         self.last_time_of_failure = None
         self.timestamp = time.time()
 
+        # lock to guard all shared state against concurrent access
+        self._lock = threading.Lock()
+
     def open(self) -> None:
         self.state = CircuitBreakerState.OPEN
         self.last_time_of_failure = time.time()
@@ -54,21 +57,27 @@ class CircuitBreaker:
         return time.time() - self.last_time_of_failure >= self.timeout
 
     def make_remote_call(self, func) -> typing.Any:
-        if self.state == CircuitBreakerState.OPEN:
-            if not self.handle_reset_state():
-                return None
-            self.half_open()  # transition to half open state to test the remote call
+        # acquire lock for the full state between check and transition
+        with self._lock:
+            if self.state == CircuitBreakerState.OPEN:
+                if not self.handle_reset_state():
+                    raise CircuitBreakerException(
+                        "Circuit is still OPEN, call rejected until timeout exhausted"
+                    )
+                self.half_open()
 
         try:
             result_value = func()
-            if self.state == CircuitBreakerState.HALF_OPEN:
-                self.close()
+            with self._lock:
+                if self.state == CircuitBreakerState.HALF_OPEN:
+                    self.close()
             return result_value
         except Exception as e:
-            self.failure_counts += 1
-            if self.handle_open_state():
-                self.open()
-            raise CircuitBreakerException
+            with self._lock:
+                self.failure_counts += 1
+                if self.handle_open_state():
+                    self.open()
+            raise CircuitBreakerException(f"Remote call failed: {e}") from e
 
 
 # wrapped it as around decorator so it's easily extended
@@ -97,6 +106,7 @@ class ServiceRegistry:
             "duration": 0,
         }
         self.timestamp = time.time()
+        self._lock = threading.Lock()
         self._setup_logger()
 
     def _setup_logger(self) -> None:
@@ -117,51 +127,57 @@ class ServiceRegistry:
         self.logger.info(message)
 
     def register_services(self, service_name: str, service_url: str) -> None:
-        if service_name in self.registered_services:
-            raise ValueError(
-                "Service already registered, please use another service name"
-            )
-        self.registered_services[service_name] = {
-            "url": service_url,
-            "service_name": service_name,
-            "assigned": False,
-            "assigned_service": None,
-            "healthy": True,
-            "availability": ServiceRegistryState.STARTING,
-        }
+        with self._lock:
+            if service_name in self.registered_services:
+                raise ValueError(
+                    "Service already registered, please use another service name"
+                )
+            self.registered_services[service_name] = {
+                "url": service_url,
+                "service_name": service_name,
+                "assigned": False,
+                "assigned_service": None,
+                "healthy": True,
+                "availability": ServiceRegistryState.STARTING,
+            }
         self.log("Success registered the service name")
 
     def get_service(self, service_name: str) -> str:
-        if service_name not in self.registered_services:
-            raise ValueError(
-                "Service name is not registered in the list of service register"
-            )
-        if not self.registered_services[service_name]["healthy"]:
-            raise ValueError("Service name is not healthy")
-        return self.registered_services[service_name]["url"]
+        with self._lock:
+            if service_name not in self.registered_services:
+                raise ValueError(
+                    "Service name is not registered in the list of service register"
+                )
+            if not self.registered_services[service_name]["healthy"]:
+                raise ValueError("Service name is not healthy")
+            return self.registered_services[service_name]["url"]
 
     @property
     def list_of_all_services(self) -> list:
-        return list(self.registered_services.keys())
+        with self._lock:
+            return list(self.registered_services.keys())
 
     def simulate_service_is_unhealthy(self, service_name: str) -> None:
-        if service_name not in self.registered_services:
-            raise ValueError(
-                "Service name is not registered in the list of service register"
-            )
+        with self._lock:
+            if service_name not in self.registered_services:
+                raise ValueError(
+                    "Service name is not registered in the list of service register"
+                )
 
-        service_availability = self.registered_services[service_name]["availability"]
+            service_availability = self.registered_services[service_name][
+                "availability"
+            ]
 
-        if self.registered_services[service_name]["healthy"]:
-            if service_availability == ServiceRegistryState.AVAILABLE:
-                # simulate when the service is healthy, change the
-                # availability, healthy status to down and also
-                # increase the numbers of failure count
-                self.registered_services[service_name][
-                    "availability"
-                ] = ServiceRegistryState.DOWN
-                self.registered_services[service_name]["healthy"] = False
-                self.service_tracing["failure_requests"] += 1
+            if self.registered_services[service_name]["healthy"]:
+                if service_availability == ServiceRegistryState.AVAILABLE:
+                    # simulate when the service is healthy, change the
+                    # availability, healthy status to down and also
+                    # increase the numbers of failure count
+                    self.registered_services[service_name][
+                        "availability"
+                    ] = ServiceRegistryState.DOWN
+                    self.registered_services[service_name]["healthy"] = False
+                    self.service_tracing["failure_requests"] += 1
 
     def _get_service_name_url(self, service_name: str) -> str:
         if service_name in self.registered_services:
@@ -169,36 +185,38 @@ class ServiceRegistry:
         return None
 
     def get_available_services(self, service_name: str) -> str:
-        if service_name in self.registered_services:
-            if self.registered_services[service_name]["assigned"]:
-                assigned_service = self.registered_services[service_name][
-                    "assigned_service"
-                ]
-                return self._get_service_name_url(assigned_service)
+        with self._lock:
+            if service_name in self.registered_services:
+                if self.registered_services[service_name]["assigned"]:
+                    assigned_service = self.registered_services[service_name][
+                        "assigned_service"
+                    ]
+                    return self._get_service_name_url(assigned_service)
 
-        if service_name in self.registered_services:
-            if self.registered_services[service_name]["healthy"]:
-                return self._get_service_name_url(service_name)
+            if service_name in self.registered_services:
+                if self.registered_services[service_name]["healthy"]:
+                    return self._get_service_name_url(service_name)
 
-        available_services = [
-            name
-            for name, data in self.registered_services.items()
-            if data["availability"] == ServiceRegistryState.AVAILABLE
-        ]
+            available_services = [
+                name
+                for name, data in self.registered_services.items()
+                if data["availability"] == ServiceRegistryState.AVAILABLE
+            ]
 
-        # currently, this function would be picked
-        # the available service based on the first index
-        if available_services:
-            return self._get_service_name_url(available_services[0])
+            # currently, this function would be picked
+            # the available service based on the first index
+            if available_services:
+                return self._get_service_name_url(available_services[0])
 
         return None
 
     def gracefully_shutdown(self, service_name: str) -> None:
-        if service_name in self.registered_services:
-            self.registered_services[service_name][
-                "availability"
-            ] = ServiceRegistryState.DOWN
-            self.deregister_service(service_name)
+        with self._lock:
+            if service_name in self.registered_services:
+                self.registered_services[service_name][
+                    "availability"
+                ] = ServiceRegistryState.DOWN
+        self.deregister_service(service_name)
 
     def _health_check(self) -> None:
         while True:
@@ -217,52 +235,69 @@ class ServiceRegistry:
     @circuit_breaker(threhsold=3, timeout=5)
     def _simulate_health_check(self, service_name: str) -> bool:
         try:
-            service_url = self.registered_services[service_name]["url"]
+            with self._lock:
+                if service_name not in self.registered_services:
+                    return None
+                service_url = self.registered_services[service_name]["url"]
+
             response = self._make_http_request(service_url)
+
             if response.status_code == 200:
-                self.registered_services[service_name][
-                    "availability"
-                ] = ServiceRegistryState.AVAILABLE
-                self.registered_services[service_name]["healthy"] = True
-                self.service_tracing["successful_requests"] += 1
+                with self._lock:
+                    self.registered_services[service_name][
+                        "availability"
+                    ] = ServiceRegistryState.AVAILABLE
+                    self.registered_services[service_name]["healthy"] = True
+                    self.service_tracing["successful_requests"] += 1
                 self.log("Related service is healthy")
                 return True
         except requests.exceptions.RequestException as e:
-            self.registered_services[service_name][
-                "availability"
-            ] = ServiceRegistryState.DOWN
-            self.registered_services[service_name]["healthy"] = False
-            self.service_tracing["failure_requests"] += 1
+            with self._lock:
+                if service_name in self.registered_services:
+                    self.registered_services[service_name][
+                        "availability"
+                    ] = ServiceRegistryState.DOWN
+                    self.registered_services[service_name]["healthy"] = False
+                    self.service_tracing["failure_requests"] += 1
             self.log(f"Related service is unhealthy due to error: {e}")
             raise
         return False
 
     def assign_service(self, service_name: str, assigned_service_name: str) -> None:
-        if service_name in self.registered_services:
-            if assigned_service_name in self.registered_services:
-                if self.registered_services[assigned_service_name]["healthy"]:
-                    self.registered_services[service_name]["assigned"] = True
-                    self.registered_services[service_name][
-                        "assigned_service"
-                    ] = assigned_service_name
-                    self.log("Success assigned one service to the available service")
-                else:
-                    self.log("Failed to assigned one service to the available service")
+        with self._lock:
+            if service_name in self.registered_services:
+                if assigned_service_name in self.registered_services:
+                    if self.registered_services[assigned_service_name]["healthy"]:
+                        self.registered_services[service_name]["assigned"] = True
+                        self.registered_services[service_name][
+                            "assigned_service"
+                        ] = assigned_service_name
+                        self.log(
+                            "Success assigned one service to the available service"
+                        )
+                    else:
+                        self.log(
+                            "Failed to assigned one service to the available service"
+                        )
 
     def deregister_service(self, service_name: str) -> None:
-        if service_name not in self.registered_services:
-            raise ValueError(
-                "Service name is not registered in the list of service register"
-            )
-        del self.registered_services[service_name]
+        with self._lock:
+            if service_name not in self.registered_services:
+                raise ValueError(
+                    "Service name is not registered in the list of service register"
+                )
+            del self.registered_services[service_name]
         self.log(f"Deleted {service_name} service instance")
 
     def deregister_all_services(self) -> None:
         # i'm not sure why this method would be called
         # after the process is completed
         for service_name in self.list_of_all_services:
-            self.deregister_service(service_name)
-            self.log("Deleted all registered services name")
+            try:
+                self.deregister_service(service_name)
+            except ValueError:
+                pass  # already removed during concurrent process
+        self.log("Deleted all registered services name")
 
     def start_health_check(self) -> None:
         health_check_thread = threading.Thread(target=self._health_check)
@@ -271,22 +306,24 @@ class ServiceRegistry:
 
     def get_services_information(self) -> dict:
         services_result = {}
-        for service_name, service_data in self.registered_services.items():
-            services_result[service_name] = {
-                "url": service_data["url"],
-                "assigned": service_data["assigned"],
-                "assigned_service": service_data["assigned_service"],
-                "availability": service_data["availability"].value,
-            }
+        with self._lock:
+            for service_name, service_data in self.registered_services.items():
+                services_result[service_name] = {
+                    "url": service_data["url"],
+                    "assigned": service_data["assigned"],
+                    "assigned_service": service_data["assigned_service"],
+                    "availability": service_data["availability"].value,
+                }
         return services_result
 
     def trace_service_request(self, service_name: str) -> None:
         start_time = time.time()
 
-        if service_name not in self.registered_services:
-            raise ValueError(
-                "Service name is not registered in the list of service register"
-            )
+        with self._lock:
+            if service_name not in self.registered_services:
+                raise ValueError(
+                    "Service name is not registered in the list of service register"
+                )
 
         try:
             # simulate a request to the certain service
@@ -299,13 +336,14 @@ class ServiceRegistry:
             end_time = time.time()
             duration = end_time - start_time
 
-            self.service_tracing["total_requests"] += 1
-            if success:
-                self.service_tracing["successful_requests"] += 1
-            else:
-                self.service_tracing["failure_requests"] += 1
+            with self._lock:
+                self.service_tracing["total_requests"] += 1
+                if success:
+                    self.service_tracing["successful_requests"] += 1
+                else:
+                    self.service_tracing["failure_requests"] += 1
 
-            self.service_tracing["duration"] += duration
+                self.service_tracing["duration"] += duration
 
 
 class ServiceRegistryManagement(ServiceRegistry):

--- a/service_registry.py
+++ b/service_registry.py
@@ -84,10 +84,15 @@ class CircuitBreaker:
 # onto ServiceRegistry() classes
 def circuit_breaker(threhsold: int, timeout: int):
     def decorator(func):
-        circuit_breaker = CircuitBreaker(threhsold, timeout)
-
-        def wrapper(*args, **kwargs):
-            return circuit_breaker.make_remote_call(lambda: func(*args, **kwargs))
+        def wrapper(self, service_name, *args, **kwargs):
+            # one breaker per service so when a failing one
+            # won't be tripping the breaker for health checks
+            breaker = self._circuit_breakers.setdefault(
+                service_name, CircuitBreaker(threhsold, timeout)
+            )
+            return breaker.make_remote_call(
+                lambda: func(self, service_name, *args, **kwargs)
+            )
 
         return wrapper
 
@@ -108,6 +113,7 @@ class ServiceRegistry:
         self.timestamp = time.time()
         self._lock = threading.Lock()
         self._setup_logger()
+        self._circuit_breakers: dict[str, CircuitBreaker] = {}
 
     def _setup_logger(self) -> None:
         self.logger = logging.getLogger(f"service_registry_{id(self)}")
@@ -221,8 +227,15 @@ class ServiceRegistry:
     def _health_check(self) -> None:
         while True:
             try:
-                for service_name in self.registered_services:
-                    self._simulate_health_check(service_name)
+                # snapshot the lock before iterating avoiding race condition
+                with self._lock:
+                    service_names = list(self.registered_services.keys())
+
+                for service_name in service_names:
+                    try:
+                        self._simulate_health_check(service_name=service_name)
+                    except CircuitBreakerException as e:
+                        self.log(f"Health check skipped for {service_name}")
             except Exception as e:
                 self.log(f"Health check error: {e}")
             time.sleep(self.health_check_interval)
@@ -287,6 +300,8 @@ class ServiceRegistry:
                     "Service name is not registered in the list of service register"
                 )
             del self.registered_services[service_name]
+            # drop any circuit breaker for this service
+            self._circuit_breakers.pop(service_name, None)
         self.log(f"Deleted {service_name} service instance")
 
     def deregister_all_services(self) -> None:

--- a/service_registry.py
+++ b/service_registry.py
@@ -2,9 +2,9 @@ import logging
 import requests
 import time
 import threading
-import atexit
 import enum
 import typing
+from config import DEFAULT_HEADERS
 
 
 class CircuitBreakerException(BaseException):
@@ -96,20 +96,24 @@ class ServiceRegistry:
             "duration": 0,
         }
         self.timestamp = time.time()
+        self._setup_logger()
+
+    def _setup_logger(self) -> None:
+        self.logger = logging.getLogger(f"service_registry_{id(self)}")
+        self.logger.setLevel(logging.DEBUG)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter(
+                    fmt="%(asctime)s : %(filename)s : %(funcName)s : %(message)s",
+                    datefmt="%d-%m-%Y %I:%M:%S",
+                ),
+            )
+            self.logger.addHandler(handler)
+        self.logger.propagate = False
 
     def log(self, message: str) -> None:
-        logger = logging.getLogger("http_service_registry_logs")
-        log_handler = logging.StreamHandler()
-        log_handler.setFormatter(
-            logging.Formatter(
-                fmt="%(asctime)s : %(filename)s : %(funcName)s : %(message)s",
-                datefmt="%d-%m-%Y %I:%M:%S",
-            ),
-        )
-        logger.addHandler(log_handler)
-        logger.setLevel(logging.DEBUG)
-        logger.propagate = True
-        logger.info(message)
+        self.logger.info(message)
 
     def register_services(self, service_name: str, service_url: str) -> None:
         if service_name in self.registered_services:
@@ -197,44 +201,39 @@ class ServiceRegistry:
 
     def _health_check(self) -> None:
         while True:
-            for service_name in self.registered_services:
-                is_service_healthy = self._simulate_health_check(service_name)
-                self.registered_services[service_name]["healthy"] = is_service_healthy
+            try:
+                for service_name in self.registered_services:
+                    self._simulate_health_check(service_name)
+            except Exception as e:
+                self.log(f"Health check error: {e}")
             time.sleep(self.health_check_interval)
 
     def _make_http_request(self, service_url: str) -> requests.Response:
-        session = requests.Session()
-        response = session.get(url=service_url)
+        response = requests.get(url=service_url, headers=DEFAULT_HEADERS, timeout=10)
         response.raise_for_status()
         return response
 
     @circuit_breaker(threhsold=3, timeout=5)
-    def _simulate_health_check(self, service_name: str) -> None:
-        while True:
-            try:
-                service_url = self.registered_services[service_name]["url"]
-                response = self._make_http_request(service_url)
-                if response.status_code == 200:
-                    if self.registered_services[service_name]["healthy"]:
-                        self.registered_services[service_name][
-                            "availability"
-                        ] = ServiceRegistryState.AVAILABLE
-                        self.registered_services[service_name]["healthy"] = True
-                        self.log("Related service is healthy")
-                    else:
-                        self.registered_services[service_name][
-                            "availability"
-                        ] = ServiceRegistryState.DOWN
-                        self.registered_services[service_name]["healthy"] = False
-                        self.log("Related service is unhealthy")
-            except requests.exceptions.RequestException as e:
-                self.registered_services[service_name]["healthy"] = False
-
-                # marked all of the exceptions that occurs as failure request
-                self.service_tracing["failure_requests"] += 1
-                raise Exception(f"Unable to make a request due of error : {e}")
-
-            time.sleep(self.health_check_interval)
+    def _simulate_health_check(self, service_name: str) -> bool:
+        try:
+            service_url = self.registered_services[service_name]["url"]
+            response = self._make_http_request(service_url)
+            if response.status_code == 200:
+                self.registered_services[service_name][
+                    "availability"
+                ] = ServiceRegistryState.AVAILABLE
+                self.registered_services[service_name]["healthy"] = True
+                self.log("Related service is healthy")
+                return True
+        except requests.exceptions.RequestException as e:
+            self.registered_services[service_name][
+                "availability"
+            ] = ServiceRegistryState.DOWN
+            self.registered_services[service_name]["healthy"] = False
+            self.service_tracing["failure_requests"] += 1
+            self.log(f"Related service is unhealthy due to error: {e}")
+            return False
+        return False
 
     def assign_service(self, service_name: str, assigned_service_name: str) -> None:
         if service_name in self.registered_services:
@@ -335,80 +334,3 @@ class ServiceRegistryManagement(ServiceRegistry):
             # for now just align the sleep interval with the health check
             time.sleep(self.health_check_interval)
         return True
-
-
-if __name__ == "__main__":
-    registry = ServiceRegistry()
-
-    # register all the related services
-    registry.register_services(
-        "GetSinglePost", "https://jsonplaceholder.typicode.com/posts/1"
-    )
-    registry.register_services(
-        "GetAllPosts", "https://jsonplaceholder.typicode.com/posts"
-    )
-
-    registry.start_health_check()
-
-    check_duration = time.sleep(5)
-    while check_duration:
-        pass
-
-    result_val = registry.get_services_information()
-    print(result_val)
-
-    # tracing between request
-    registry.trace_service_request("GetSinglePost")
-    print(registry.service_tracing)
-
-    registry.get_service("GetSinglePost")
-
-    # simulate the one of the services are unhealthy
-    registry.simulate_service_is_unhealthy("GetSinglePost")
-
-    print(registry.service_tracing)
-
-    # assign the "unhealthy" services to the available service
-    registry.assign_service("GetSinglePost", "GetAllPosts")
-
-    get_url = registry.get_available_services("GetSinglePost")
-    print(get_url)
-
-    # usage of extended service registry
-    # first, we need to register the services first and initialize the instance
-    extended_registry = ServiceRegistryManagement()
-    extended_registry.register_services(
-        "ServiceA", "https://jsonplaceholder.typicode.com/posts/1"
-    )
-    extended_registry.register_services(
-        "ServiceB", "https://jsonplaceholder.typicode.com/posts/2"
-    )
-
-    # and now we will register for each dependencies
-    extended_registry.register_dependency("ServiceA", "ServiceB")
-
-    # check whether the dependent service is available or not
-    get_services_ready = extended_registry.is_service_ready("ServiceB")
-    if get_services_ready:
-        print("Each services are ready, no need to wait")
-    else:
-        # wait another services until it's ready
-        extended_registry.wait_for_dependencies("ServiceB")
-
-    # this will thrown a failure since the service name is unhealthy
-    # and all of the process will halted directly
-    # registry.get_service("GetSinglePost")
-
-    # de-register all of the services whether it's up or down
-    # registry.deregister_all_services()
-
-    # de-register a certain service based on the service name
-    # registry.deregister_service("GetAllPosts")
-
-    # gracefully shutdown a single service
-    registry.gracefully_shutdown("GetSinglePost")
-
-    # this will return the value as None since we already
-    # gracefully shut-in down the GetSinglePost service
-    get_url = registry.get_available_services("GetSinglePost")
-    print(get_url)

--- a/service_registry.py
+++ b/service_registry.py
@@ -5,6 +5,7 @@ import threading
 import enum
 import typing
 from config import DEFAULT_HEADERS
+from metrics import record_event
 
 
 class CircuitBreakerException(Exception):
@@ -147,6 +148,7 @@ class ServiceRegistry:
                 "availability": ServiceRegistryState.STARTING,
             }
         self.log("Success registered the service name")
+        record_event(service_name, "service_registered", service_url)
 
     def get_service(self, service_name: str) -> str:
         with self._lock:
@@ -164,6 +166,7 @@ class ServiceRegistry:
             return list(self.registered_services.keys())
 
     def simulate_service_is_unhealthy(self, service_name: str) -> None:
+        changed = False
         with self._lock:
             if service_name not in self.registered_services:
                 raise ValueError(
@@ -184,6 +187,9 @@ class ServiceRegistry:
                     ] = ServiceRegistryState.DOWN
                     self.registered_services[service_name]["healthy"] = False
                     self.service_tracing["failure_requests"] += 1
+                    changed = True
+        if changed:
+            record_event(service_name, "service_failure", "simulated failure")
 
     def _get_service_name_url(self, service_name: str) -> str:
         if service_name in self.registered_services:
@@ -252,6 +258,9 @@ class ServiceRegistry:
                 if service_name not in self.registered_services:
                     return None
                 service_url = self.registered_services[service_name]["url"]
+                previous_availability = self.registered_services[service_name][
+                    "availability"
+                ]
 
             response = self._make_http_request(service_url)
 
@@ -263,20 +272,38 @@ class ServiceRegistry:
                     self.registered_services[service_name]["healthy"] = True
                     self.service_tracing["successful_requests"] += 1
                 self.log("Related service is healthy")
+                if previous_availability != ServiceRegistryState.AVAILABLE:
+                    record_event(
+                        service_name,
+                        "health_check_healthy",
+                        "state changed to AVAILABLE",
+                    )
                 return True
         except requests.exceptions.RequestException as e:
+            previous_availability = None
             with self._lock:
                 if service_name in self.registered_services:
+                    previous_availability = self.registered_services[service_name][
+                        "availability"
+                    ]
                     self.registered_services[service_name][
                         "availability"
                     ] = ServiceRegistryState.DOWN
                     self.registered_services[service_name]["healthy"] = False
                     self.service_tracing["failure_requests"] += 1
             self.log(f"Related service is unhealthy due to error: {e}")
+            if (
+                previous_availability is not None
+                and previous_availability != ServiceRegistryState.DOWN
+            ):
+                record_event(
+                    service_name, "health_check_unhealthy", "state changed to DOWN"
+                )
             raise
         return False
 
     def assign_service(self, service_name: str, assigned_service_name: str) -> None:
+        assigned = False
         with self._lock:
             if service_name in self.registered_services:
                 if assigned_service_name in self.registered_services:
@@ -288,10 +315,17 @@ class ServiceRegistry:
                         self.log(
                             "Success assigned one service to the available service"
                         )
+                        assigned = True
                     else:
                         self.log(
                             "Failed to assigned one service to the available service"
                         )
+        if assigned:
+            record_event(
+                service_name,
+                "service_assigned",
+                f"{service_name} assigned to {assigned_service_name}",
+            )
 
     def deregister_service(self, service_name: str) -> None:
         with self._lock:
@@ -303,6 +337,7 @@ class ServiceRegistry:
             # drop any circuit breaker for this service
             self._circuit_breakers.pop(service_name, None)
         self.log(f"Deleted {service_name} service instance")
+        record_event(service_name, "service_deregistered", service_name)
 
     def deregister_all_services(self) -> None:
         # i'm not sure why this method would be called
@@ -360,6 +395,8 @@ class ServiceRegistry:
 
                 self.service_tracing["duration"] += duration
 
+        record_event(service_name, "request_traced", service_name)
+
 
 class ServiceRegistryManagement(ServiceRegistry):
     def __init__(self) -> None:
@@ -372,6 +409,11 @@ class ServiceRegistryManagement(ServiceRegistry):
         self.dependency_map[service_name].append(depends_on)
         self.log(
             f"Successful register the dependencies between {service_name} that depends on {depends_on} services"
+        )
+        record_event(
+            service_name,
+            "dependency_registered",
+            f"{service_name} depends on {depends_on}",
         )
 
     def get_dependencies(self, service_name: str) -> typing.Any:

--- a/services.py
+++ b/services.py
@@ -1,0 +1,39 @@
+from service_registry import ServiceRegistryManagement
+from config import DOWNSTREAM_SERVICES
+
+registry = ServiceRegistryManagement()
+
+for name, url in DOWNSTREAM_SERVICES.items():
+    registry.register_services(service_name=name, service_url=url)
+
+# assign the services based on the dependency
+registry.assign_service(
+    service_name="FE-Chat-Health-Apache-Proxy",
+    assigned_service_name="FE-Chat-Health-Node-Proxy",
+)
+registry.assign_service(
+    service_name="FE-Chat-Health-Node-Proxy",
+    assigned_service_name="BE-Chat-Health",
+)
+
+# register the dependencies between the services
+# create a topology of the services based on the deps
+registry.register_dependency(
+    service_name="FE-Chat-Health-Node-Proxy",
+    depends_on="BE-Chat-Health",
+)
+registry.register_dependency(
+    service_name="FE-Chat-Health-Apache-Proxy",
+    depends_on="FE-Chat-Health-Node-Proxy",
+)
+registry.register_dependency(
+    service_name="Maukerja-Server",
+    depends_on="V3-API-BE",
+)
+registry.register_dependency(
+    service_name="Maukerja-Server",
+    depends_on="BE-Chat-Health",
+)
+
+# start the health check for the downstream services
+registry.start_health_check()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,61 @@
+import requests
+from time import time
+from config import DEFAULT_HEADERS
+
+
+def check_downstream_health(
+    services_dict: dict, headers: dict = None
+) -> dict[str, any]:
+    """
+    Utility function to check the health of downstream services,
+    it will return the status of each service and the overall status of all services
+    """
+    services = []
+    # falback to default headers if no custom headers provided
+    if headers is None:
+        headers = DEFAULT_HEADERS
+
+    all_healthy = True
+    any_healthy = False
+
+    for name, url in services_dict.items():
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            status_code = response.status_code
+            healthy = status_code == 200
+            try:
+                body = response.json()
+            except ValueError:
+                body = response.text
+        except requests.RequestException as e:
+            status_code = 0
+            healthy = False
+            body = str(e)
+
+        if healthy:
+            any_healthy = True
+        else:
+            all_healthy = False
+
+        services.append(
+            {
+                "name": name,
+                "url": url,
+                "status_code": status_code,
+                "healthy": healthy,
+                "response": body,
+            }
+        )
+
+    if all_healthy:
+        status = "healthy"
+    elif any_healthy:
+        status = "degraded"
+    else:
+        status = "unhealthy"
+
+    return {
+        "status": status,
+        "timestamp": int(time() * 1000),
+        "services": services,
+    }


### PR DESCRIPTION
### Bugfixes
- #1 
- #2 
- #3 
- #4 
- #5 

### Changes
- Add helper utilities to check the downstream services as part of external health
- Remove unnecessary and dead code in the core API of service registry module
- Setup `Dockerfile` and docker compose as a main stack on how to wired service registry
- Add `threading.Lock` and wrapped all state reads/writes so it doesn't block other threads
- Raise `CircuitBreakerException` with proper instances, not from the class
- Write a new API endpoint to expose event history metrics on the service registry
- Implement SQLite-backed event history which is used for service registry assignment
- Avoid race conditionin the `health_check` by adding snapshots before iterating
- `@circuit_breaker` decorators now applied per-service so it won't trip over when service fails
- Remove all the corresponding circuit breaker entry to avoid memory grow bigger

### Docs
- Add comprehensive documentation on how to wired up service registry management into actual services